### PR TITLE
Prepare RQDA code for translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+po/R-RQDA.pot
+po/*.po~
+inst/po/

--- a/R/AddNewFileFunOfCase.R
+++ b/R/AddNewFileFunOfCase.R
@@ -12,14 +12,14 @@ AddNewFileFunOfCase <- function ()
         UpdateFileofCaseWidget()
     }
 
-    gw <- gwindow(title = "Add a new file to selected case", parent = getOption("widgetCoordinate"),
+    gw <- gwindow(title = gettext("Add a new file to selected case", domain = "R-RQDA"), parent = getOption("widgetCoordinate"),
                   width = getOption("widgetSize")[1], height = getOption("widgetSize")[2])
     mainIcon <- system.file("icon", "mainIcon.png", package = "RQDA")
     gw@widget@widget$SetIconFromFile(mainIcon)
     gp <- gpanedgroup(horizontal = FALSE, container=gw)
 
     saveFileFun <- function() {
-        Ftitle <- ginput("Enter the title", icon = "info")
+        Ftitle <- ginput(gettext("Enter the title", domain = "R-RQDA"), icon = "info")
         if (!is.na(Ftitle)) {
             Ftitle <- enc(Ftitle, "UTF-8")
             if (nrow(dbGetQuery(.rqda$qdacon, sprintf("select name from source where name='%s'", Ftitle))) != 0) {
@@ -45,7 +45,7 @@ AddNewFileFunOfCase <- function ()
     }
 
     gl <- glayout(homogeneous = TRUE, container = gp)
-    AddNewFilBC <- gbutton("Save", handler = function(h, ...) {
+    AddNewFilBC <- gbutton(gettext("Save", domain = "R-RQDA"), handler = function(h, ...) {
         suc <- saveFileFun()
         if (suc)
             dispose(gw)

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -62,7 +62,7 @@ EditVarWidget <- function(ExistingItems=NULL,container=NULL,title=NULL,ID=NULL,s
   ## create window, etc
   window <- gtkWindowNew("toplevel", show = F)
   Encoding(title) <- 'UTF-8'
-  window$setTitle(paste("Attribute of:",title))
+  window$setTitle(paste(gettext("Attribute of:", domain = "R-RQDA"), title))
   window$setBorderWidth(5)
   vbox <- gtkVBoxNew(FALSE, 5)
   window$add(vbox)
@@ -81,7 +81,7 @@ EditVarWidget <- function(ExistingItems=NULL,container=NULL,title=NULL,ID=NULL,s
   ## some buttons
   hbox <- gtkHBoxNew(TRUE, 4)
   vbox$packStart(hbox, FALSE, FALSE, 0)
-  button <- gtkButtonNewWithLabel("Save and Close")
+  button <- gtkButtonNewWithLabel(gettext("Save and Close", domain = "R-RQDA"))
   gSignalConnect(button, "clicked",saveFUN,list(model,window,ExistingItems,list(...)))
   hbox$packStart(button, TRUE, TRUE, 0)
   window$setDefaultSize(300, 350)
@@ -132,7 +132,7 @@ saveFUN4CaseAttr <- function(button,data){
 
 CaseAttrFun <- function(caseId,title=NULL,attrs=svalue(.rqda$.AttrNamesWidget)){
   if (length(attrs)==0) attrs <-  dbGetQuery(.rqda$qdacon,"select name from attributes where status=1")$name
-  if (is.null(attrs)) gmessage("add attribute in Attrs Tabe first.",container=TRUE) else{
+  if (is.null(attrs)) gmessage(gettext("add attribute in Attrs Table first.", domain = "R-RQDA"),container=TRUE) else{
     attrs2 <- data.frame(variable=attrs,value="NA",stringsAsFactors=FALSE)
     variables <- dbGetQuery(.rqda$qdacon,sprintf("select variable, value from caseAttr where caseID=%i and variable in (%s) and status=1", caseId,paste(shQuote(attrs),collapse=",")))
     if (nrow(variables)!=0){
@@ -186,7 +186,7 @@ saveFUN4FileAttr <- function(button,data){
 
 FileAttrFun <- function(fileId,title=NULL,attrs=svalue(.rqda$.AttrNamesWidget)){
   if (length(attrs)==0) attrs <-  dbGetQuery(.rqda$qdacon,"select name from attributes where status=1")$name
-  if (is.null(attrs)) gmessage("add attribute in Attrs Tabe first.",container=TRUE) else{
+  if (is.null(attrs)) gmessage(gettext("add attribute in Attrs Table first.", domain = "R-RQDA"),container=TRUE) else{
     Encoding(attrs) <- 'UTF-8'
     attrs2 <- data.frame(variable=attrs,value="NA",stringsAsFactors=FALSE)
     variables <- dbGetQuery(.rqda$qdacon,sprintf("select variable, value from fileAttr where fileID=%i and variable in (%s) and status=1",fileId,paste(shQuote(attrs),collapse=",")))
@@ -231,17 +231,17 @@ AddAttrNames <- function(name,...) {
   }
 }
 
-AddAttrButton <- function(label="ADD"){
+AddAttrButton <- function(label=gettext("ADD", domain = "R-RQDA")){
   AddAttB <- gbutton(label,handler=function(h,...) {
-    AttrName <- ginput("Enter new Attr Name. ", icon="info")
+    AttrName <- ginput(gettext("Enter new Attr Name. ", domain = "R-RQDA"), icon="info")
     if (!is.na(AttrName)) {
       Encoding(AttrName) <- "UTF-8"
       invalid <- grepl("'",AttrName)
       if (invalid) {
-        gmessage("Attribute should NOT contain '.",container=TRUE)
+        gmessage(gettext("Attribute should NOT contain '.", domain = "R-RQDA"),container=TRUE)
       } else {
         if (AttrName %in% c("fileID","caseID")) {
-          gmessage("This is a reserved keyword.",container=TRUE)
+          gmessage(gettext("This is a reserved keyword.", domain = "R-RQDA"),container=TRUE)
         } else{
           AddAttrNames(AttrName)
           AttrNamesUpdate()
@@ -256,9 +256,9 @@ AddAttrButton <- function(label="ADD"){
 }
 
 
-DeleteAttrButton <- function(label="Delete"){
+DeleteAttrButton <- function(label=gettext("Delete", domain = "R-RQDA")){
   DelAttB <- gbutton(label,handler=function(h,...) {
-    del <- gconfirm("Really delete the Attribute?",icon="question")
+    del <- gconfirm(gettext("Really delete the Attribute?", domain = "R-RQDA"),icon="question")
     if (isTRUE(del)){
       Selected <- svalue(.rqda$.AttrNamesWidget)
       Selected <- enc(Selected,"UTF-8")
@@ -275,20 +275,20 @@ DeleteAttrButton <- function(label="Delete"){
 }
 
 
-RenameAttrButton <- function(label="Rename"){
+RenameAttrButton <- function(label=gettext("Rename", domain = "R-RQDA")){
   RenAttB <- gbutton(label,handler=function(h,...) {
     selected <- svalue(.rqda$.AttrNamesWidget)
-    NewName <- ginput("Enter new attribute name. ", text=selected, icon="info")
+    NewName <- ginput(gettext("Enter new attribute name. ", domain = "R-RQDA"), text=selected, icon="info")
     if (!is.na(NewName)){
       Encoding(NewName) <- "UTF-8"
       selected <- enc(selected,encoding="UTF-8")
       invalid <- grepl("'",NewName)
       if (invalid) {
-        gmessage("Attribute should NOT contain '.",container=TRUE)
+        gmessage(gettext("Attribute should NOT contain '.", domain = "R-RQDA"),container=TRUE)
       } else {
         exists <- dbGetQuery(.rqda$qdacon, sprintf("select * from attributes where name = '%s' ",NewName))
         if (nrow(exists) > 0 ){
-          gmessage("Name duplicated. Please use anaother name.",cont=TRUE)
+          gmessage(gettext("Name duplicated. Please use another name.", domain = "R-RQDA"),cont=TRUE)
         } else {
           dbGetQuery(.rqda$qdacon, sprintf("update attributes set name = '%s' where name = '%s' ",NewName,selected))
           dbGetQuery(.rqda$qdacon, sprintf("update caseAttr set variable = '%s' where variable = '%s' ",NewName,selected))
@@ -304,9 +304,9 @@ RenameAttrButton <- function(label="Rename"){
   RenAttB
 }
 
-AttrMemoButton <- function(label="Memo"){
+AttrMemoButton <- function(label=gettext("Memo", domain = "R-RQDA")){
   AttMemB <- gbutton(label,handler=function(h,...) {
-    MemoWidget("Attributes",.rqda$.AttrNamesWidget,"attributes")
+    MemoWidget(gettext("Attributes", domain = "R-RQDA"),.rqda$.AttrNamesWidget,"attributes")
   }
                      )
   assign("AttMemB",AttMemB,envir=button)
@@ -384,19 +384,19 @@ GetAttr <- function(type=c("case","file"),attrs=svalue(.rqda$.AttrNamesWidget),s
   if (missing(subset)) DF else {
       r <- eval(substitute(subset),DF)
       if (!is.logical(r))
-          stop("'subset' must evaluate to logical")
+          stop("'subset' must evaluate to logical", domain = "R-RQDA")
       r <- r & !is.na(r)
       DF <- DF[r,,drop=FALSE]
       DF
   }
 }}
 
-SetAttrClsButton <- function(label="Class"){
+SetAttrClsButton <- function(label=gettext("Class", domain = "R-RQDA")){
   ans <- gbutton(label,handler=function(h,...) {
     setAttrType()
   }
                  )
-  gtkWidgetSetTooltipText(getToolkitWidget(ans),"Set class of selected attribute.\nIt can be 'numeric' or 'character'.")
+  gtkWidgetSetTooltipText(getToolkitWidget(ans),gettext("Set class of selected attribute.\nIt can be 'numeric' or 'character'.", domain = "R-RQDA"))
   assign("SetAttClsB",ans,envir=button)
   enabled(ans) <- FALSE
   ans
@@ -417,7 +417,7 @@ setAttrType <- function() {
       items <- c("numeric","character")
       idx <- which (items %in%  oldCls)
     }
-    w <- gwindow("Type of attributes",height=30,width=150)
+    w <- gwindow(gettext("Type of attribute", domain = "R-RQDA"),height=30,width=150)
     gp <- ggroup(horizontal=FALSE,container=w)
     rb <- gradio(items,idx,horizontal=TRUE, container=gp)
     gbutton("OK",container=gp,handler=function(h,...){
@@ -434,10 +434,10 @@ importAttr <- function(data, type='file', filename){
   fn <- getFiles()
   fid <- getFiles(names=F)
   fnuser <- data[,filename]
-  if (!all(fnuser %in% fn)) stop("some files are not in the rqda project.")
+  if (!all(fnuser %in% fn)) stop("some files are not in the rqda project.", domain = "R-RQDA")
   fid <- fid[match(data[[filename]],fn)]
   allAtt <- RQDAQuery("select name from attributes where status=1")$name
-  if (!all(names(dat) %in% allAtt)) stop("some attributes are in not the rqda project.")
+  if (!all(names(dat) %in% allAtt)) stop("some attributes are in not the rqda project.", domain = "R-RQDA")
   for (att in names(dat)) {
     attval <- dat[[att]]
     if (mode(attval) == "character" && Encoding(attval) != "UTF-8") attval <- iconv(attval, to='UTF-8')
@@ -571,7 +571,7 @@ importAttr <- function(data, type='file', filename){
 
 ##   ## create window, etc
 ##   window <- gtkWindowNew("toplevel", show = F)
-##   window$setTitle(paste("Var:",title))
+##   window$setTitle(paste(gettext("Var:", domain = "R-RQDA"),title))
 ##   window$setBorderWidth(5)
 ##   vbox <- gtkVBoxNew(FALSE, 5)
 ##   window$add(vbox)

--- a/R/Boolean.R
+++ b/R/Boolean.R
@@ -1,5 +1,5 @@
 getCodingsByOne <- function(cid, fid=NULL,codingTable=c("coding","coding2")){
-    if (length(cid)!=1) stop("cid should be length-1 integer vector.")
+    if (length(cid)!=1) stop("cid should be length-1 integer vector.", domain = "R-RQDA")
     codingTable <- match.arg(codingTable)
      if (codingTable=="coding"){
     ct <- RQDAQuery(sprintf("select coding.rowid as rowid, coding.cid, coding.fid, freecode.name as codename, source.name as filename, coding.selfirst as index1, coding.selend as index2, coding.seltext as coding, coding.selend - coding.selfirst as CodingLength from coding left join freecode on (coding.cid=freecode.id) left join source on (coding.fid=source.id) where coding.status=1 and source.status=1 and freecode.status=1 and coding.cid=%s",cid))
@@ -37,15 +37,21 @@ print.codingsByOne <- function (x,...)
     }
 
     if (nrow(x) == 0)
-      gmessage("No Codings.", container = TRUE)
+      gmessage(gettext("No Codings.", domain = "R-RQDA"), container = TRUE)
     else {
         x <-x[order(x$fid,x$index1,x$index2),]
         fid <- unique(x$fid)
         Nfiles <- length(fid)
         Ncodings <- nrow(x)
-        title <- sprintf(ngettext(Ncodings, "%i coding from %s %s",
-                                  "%i codings from %s %s"), Ncodings,
-                         Nfiles, ngettext(Nfiles, "file", "files"))
+        if(Ncodings == 1){
+            title <- sprintf(ngettext(Nfiles,
+                                      "1 coding from %i file",
+                                      "1 coding from %i files", domain = "R-RQDA"), Nfiles)
+        } else {
+            title <- sprintf(ngettext(Nfiles,
+                                      "%i codings from %i file",
+                                      "%i codings from %i files", domain = "R-RQDA"), Ncodings, Nfiles)
+        }
         tryCatch(eval(parse(text = sprintf("dispose(.rqda$.codingsOf%s)",
                             "codingsByone"))), error = function(e) {
                             })
@@ -68,7 +74,7 @@ print.codingsByOne <- function (x,...)
             anchorcreated <- buffer$createChildAnchor(iter)
             iter$BackwardChar()
             anchor <- iter$getChildAnchor()
-            lab <- gtkLabelNew("Back")
+            lab <- gtkLabelNew(gettext("Back", domain = "R-RQDA"))
             widget <- gtkEventBoxNew()
             widget$Add(lab)
             gSignalConnect(widget, "button-press-event",
@@ -365,7 +371,7 @@ not <- function (CT1, CT2)
 ##     ans
 ##   } ## end of helper function.
 
-##   if (any(c(nrow(CT1),nrow(CT2))==0)) stop("One code has empty coding.")
+##   if (any(c(nrow(CT1),nrow(CT2))==0)) stop("One code has empty coding.", domain = "R-RQDA")
 ##   CT1 <- CT1[,c("rowid","fid","filename","index1","index2","coding"),drop=FALSE]
 ##   CT2 <- CT2[,c("rowid","fid","filename","index1","index2","coding"),drop=FALSE]
 ##   if (nrow(CT1) >= nrow(CT2)) {
@@ -436,7 +442,7 @@ not <- function (CT1, CT2)
 ##               ## do nothing
 ##             } else {## else4
 ##               over <- Relation %in% c("overlap")
-##               if (sum(over)>2) stop("the same text is coded twice by the same code.")
+##               if (sum(over)>2) stop("the same text is coded twice by the same code.", domain = "R-RQDA")
 
 ##               for (j in which(over)) {
 ##                 if (!is.na(relAll[[j]]$WhichMin) &&  relAll[[j]]$WhichMin==2){

--- a/R/CaseButton.R
+++ b/R/CaseButton.R
@@ -1,6 +1,6 @@
-AddCaseButton <- function(label="ADD"){
+AddCaseButton <- function(label=gettext("ADD", domain = "R-RQDA")){
   AddCasB <- gbutton(label,handler=function(h,...) {
-    CaseName <- ginput("Enter new Case Name. ", icon="info")
+    CaseName <- ginput(gettext("Enter new Case Name. ", domain = "R-RQDA"), icon="info")
     if (!is.na(CaseName)) {
       Encoding(CaseName) <- "UTF-8"
       AddCase(CaseName)
@@ -20,9 +20,9 @@ AddCaseButton <- function(label="ADD"){
 }
 
 
-DeleteCaseButton <- function(label="Delete"){
+DeleteCaseButton <- function(label=gettext("Delete", domain = "R-RQDA")){
   DelCasB <- gbutton(label, handler=function(h,...) {
-    del <- gconfirm("Really delete the Case?",icon="question")
+    del <- gconfirm(gettext("Really delete the Case?", domain = "R-RQDA"),icon="question")
     if (isTRUE(del)){
       SelectedCase <- svalue(.rqda$.CasesNamesWidget)
       Encoding(SelectedCase) <- "UTF-8"
@@ -44,13 +44,13 @@ DeleteCaseButton <- function(label="Delete"){
 }
 
 
-Case_RenameButton <- function(label="Rename",CaseNamesWidget=.rqda$.CasesNamesWidget,...)
+Case_RenameButton <- function(label=gettext("Rename", domain = "R-RQDA"),CaseNamesWidget=.rqda$.CasesNamesWidget,...)
 {
   ## rename of selected case.
   CasRenB <- gbutton(label,handler=function(h,...) {
     selectedCaseName <- svalue(CaseNamesWidget)
     ## get the new file names
-    NewName <- ginput("Enter new Case name. ", text=selectedCaseName, icon="info")
+    NewName <- ginput(gettext("Enter new Case name. ", domain = "R-RQDA"), text=selectedCaseName, icon="info")
     if (!is.na(NewName)){
       rename(selectedCaseName,NewName,"cases")
       CaseNamesUpdate()
@@ -63,7 +63,7 @@ Case_RenameButton <- function(label="Rename",CaseNamesWidget=.rqda$.CasesNamesWi
 }
 
 
-CaseMark_Button<-function(label="Mark"){
+CaseMark_Button<-function(label=gettext("Mark", domain = "R-RQDA")){
   CasMarB <- gbutton(label,handler=function(h,...) {
     MarkCaseFun()
     UpdateFileofCaseWidget()
@@ -98,7 +98,7 @@ MarkCaseFun <- function(){
         if (nrow(ExistLinkage)==0){
           ## if there are no relevant caselinkage, write the caselinkage table
           success <- dbWriteTable(.rqda$qdacon,"caselinkage",DAT,row.name=FALSE,append=TRUE)
-          if (!success) gmessage("Fail to write to database.")
+          if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
         } else {
           Relations <- apply(ExistLinkage,1,FUN=function(x) relation(x[c("selfirst","selend")],c(ans$start,ans$end)))
           ExistLinkage$Relation <- sapply(Relations,FUN=function(x)x$Relation)
@@ -109,7 +109,7 @@ MarkCaseFun <- function(){
             ExistLinkage$End <- sapply(Relations,FUN=function(x)x$UnionIndex[2])
             if (all(ExistLinkage$Relation=="proximity")){
               success <- dbWriteTable(.rqda$qdacon,"caselinkage",DAT,row.name=FALSE,append=TRUE)
-              if (!success) gmessage("Fail to write to database.")
+              if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
             } else {
               del1 <- ExistLinkage$WhichMin==2 & ExistLinkage$Relation =="inclusion"; del1[is.na(del1)] <- FALSE
               del2 <- ExistLinkage$Relation =="overlap"; del2[is.na(del2)] <- FALSE
@@ -125,7 +125,7 @@ MarkCaseFun <- function(){
                                 selfirst=Sel[1],selend=Sel[2],status=1,
                                 owner=.rqda$owner,date=date(),memo=memo)
               success <- dbWriteTable(.rqda$qdacon,"caselinkage",DAT,row.name=FALSE,append=TRUE)
-              if (!success) gmessage("Fail to write to database.")
+              if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
             }
             }
             }
@@ -137,7 +137,7 @@ MarkCaseFun <- function(){
 }
 
 
-CaseUnMark_Button<-function(label="Unmark"){
+CaseUnMark_Button<-function(label=gettext("Unmark", domain = "R-RQDA")){
   CasUnMarB <- gbutton(label, handler=function(h,...) {
     con <- .rqda$qdacon
     W <- .rqda$.openfile_gui
@@ -146,7 +146,7 @@ CaseUnMark_Button<-function(label="Unmark"){
     ## if the not file is open, unmark doesn't work.
     if (!is.null(sel_index)) {
       SelectedCase <- svalue(.rqda$.CasesNamesWidget)
-      if (length(SelectedCase)==0) {gmessage("Select a case first.",con=TRUE)} else{
+      if (length(SelectedCase)==0) {gmessage(gettext("Select a case first.", domain = "R-RQDA"),con=TRUE)} else{
         SelectedCase <- enc(SelectedCase,"UTF-8")
         caseid <-  dbGetQuery(.rqda$qdacon,sprintf("select id from cases where name='%s'",SelectedCase))[,1]
         SelectedFile <- svalue(.rqda$.root_edit)
@@ -179,7 +179,7 @@ CaseUnMark_Button<-function(label="Unmark"){
   CasUnMarB
 }
 
-CaseAttribute_Button <- function(label="Attribute"){
+CaseAttribute_Button <- function(label=gettext("Attribute", domain = "R-RQDA")){
     CasAttrB <- gbutton(text=label, handler = function(h, ...) {
         SelectedCase <- svalue(.rqda$.CasesNamesWidget)
         if (length(SelectedCase!=0)){
@@ -200,218 +200,226 @@ prof_mat_Button <- function(label="prof_mat"){
   profmatB
 }
 
-CaseNamesWidgetMenu <- list()
-CaseNamesWidgetMenu$"Add File(s)"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    SelectedCase <- svalue(.rqda$.CasesNamesWidget)
-    SelectedCase <- enc(SelectedCase,"UTF-8")
-    caseid <- dbGetQuery(.rqda$qdacon,sprintf("select id from cases where status=1 and name='%s'",SelectedCase))[,1]
-    freefile <-  dbGetQuery(.rqda$qdacon,"select name, id, file from source where status=1")
-    fileofcase <- dbGetQuery(.rqda$qdacon,sprintf("select fid from caselinkage where status=1 and caseid=%i",caseid))
-    Encoding(freefile[['name']]) <- Encoding(freefile[['file']]) <- "UTF-8"
-    if (nrow(fileofcase)!=0){
-      fileoutofcase <- subset(freefile,!(id %in% fileofcase$fid))
+GetCaseNamesWidgetMenu <- function()
+{
+  CaseNamesWidgetMenu <- list()
+  CaseNamesWidgetMenu[[gettext("Add File(s)", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      SelectedCase <- svalue(.rqda$.CasesNamesWidget)
+      SelectedCase <- enc(SelectedCase,"UTF-8")
+      caseid <- dbGetQuery(.rqda$qdacon,sprintf("select id from cases where status=1 and name='%s'",SelectedCase))[,1]
+      freefile <-  dbGetQuery(.rqda$qdacon,"select name, id, file from source where status=1")
+      fileofcase <- dbGetQuery(.rqda$qdacon,sprintf("select fid from caselinkage where status=1 and caseid=%i",caseid))
+      Encoding(freefile[['name']]) <- Encoding(freefile[['file']]) <- "UTF-8"
+      if (nrow(fileofcase)!=0){
+        fileoutofcase <- subset(freefile,!(id %in% fileofcase$fid))
       } else  fileoutofcase <- freefile
-    if (length(fileoutofcase[['name']])==0) gmessage("All files are linked with this case.", cont=TRUE) else {
-      ##Selected <- select.list(fileoutofcase[['name']],multiple=TRUE)
-    CurrentFrame <- sys.frame(sys.nframe())
-    ## sys.frame(): get the frame of n
-    ## nframe(): get n of current frame
-    ## The value of them depends on where they evaluated, should not placed inside RunOnSelected()
-    RunOnSelected(fileoutofcase[['name']],multiple=TRUE,enclos=CurrentFrame,expr={
-      if (length(Selected)> 0) {
-        Encoding(Selected) <- "UTF-8"
-        fid <- fileoutofcase[fileoutofcase$name %in% Selected,"id"]
-        selend <- nchar(fileoutofcase[fileoutofcase$name %in% Selected,"file"])
-        Dat <- data.frame(caseid=caseid,fid=fid,selfirst=0,selend=selend,status=1,owner=.rqda$owner,date=date(),memo=NA)
-        dbWriteTable(.rqda$qdacon,"caselinkage",Dat,row.names=FALSE,append=TRUE)
-        UpdateFileofCaseWidget()
-      }})
-  }
-  }
-}
-
-CaseNamesWidgetMenu$"Add New File to Selected Case"$handler <- function(h, ...) {
-  AddNewFileFunOfCase()
-}
-
-CaseNamesWidgetMenu$"Case Memo"$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-    MemoWidget("Case",.rqda$.CasesNamesWidget,"cases")
-    ## see CodeCatButton.R  for definition of MemoWidget
-  }
-}
-CaseNamesWidgetMenu$"Show Cases with Memo Only"$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-   cnames <- RQDAQuery("select name from cases where memo is not null")$name
-   if (!is.null(cnames)) cnames <- enc(cnames,"UTF-8")
-   .rqda$.CasesNamesWidget[] <- cnames
-  }
-}
-CaseNamesWidgetMenu$"Add/modify Attributes..."$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-    SelectedCase <- svalue(.rqda$.CasesNamesWidget)
-    if (length(SelectedCase!=0)){
-    SelectedCase <- enc(SelectedCase,"UTF-8")
-    caseid <- dbGetQuery(.rqda$qdacon,sprintf("select id from cases where status=1 and name='%s'",SelectedCase))[,1]
-    CaseAttrFun(caseId=caseid,title=SelectedCase)
-  }
-}}
-CaseNamesWidgetMenu$"View Attributes"$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-   viewCaseAttr()
-  }
-}
-CaseNamesWidgetMenu$"Export Case Attributes"$handler <- function(h,...){
-    if (is_projOpen(envir=.rqda,conName="qdacon")) {
-        fName <- gfile(type='save',filter=list("csv"=list(pattern=c("*.csv"))))
-        Encoding(fName) <- "UTF-8"
-        if (length(grep(".csv$",fName))==0) fName <- sprintf("%s.csv",fName)
-        write.csv(GetAttr("case"), row.names=FALSE, file=fName, na="")
+      if (length(fileoutofcase[['name']])==0) gmessage(gettext("All files are linked with this case.", domain = "R-RQDA"), cont=TRUE) else {
+        ##Selected <- select.list(fileoutofcase[['name']],multiple=TRUE)
+        CurrentFrame <- sys.frame(sys.nframe())
+        ## sys.frame(): get the frame of n
+        ## nframe(): get n of current frame
+        ## The value of them depends on where they evaluated, should not placed inside RunOnSelected()
+        RunOnSelected(fileoutofcase[['name']],multiple=TRUE,enclos=CurrentFrame,expr={
+                        if (length(Selected)> 0) {
+                          Encoding(Selected) <- "UTF-8"
+                          fid <- fileoutofcase[fileoutofcase$name %in% Selected,"id"]
+                          selend <- nchar(fileoutofcase[fileoutofcase$name %in% Selected,"file"])
+                          Dat <- data.frame(caseid=caseid,fid=fid,selfirst=0,selend=selend,status=1,owner=.rqda$owner,date=date(),memo=NA)
+                          dbWriteTable(.rqda$qdacon,"caselinkage",Dat,row.names=FALSE,append=TRUE)
+                          UpdateFileofCaseWidget()
+    }})
+      }
     }
-}
-CaseNamesWidgetMenu$"Sort All by Created Time"$handler <- function(h,...){
-  CaseNamesUpdate(.rqda$.CasesNamesWidget,sortByTime = TRUE)
-}
-CaseNamesWidgetMenu$"Web Search"$Google$handler <- function(h,...){
-  KeyWord <- svalue(.rqda$.CasesNamesWidget)
-  if (length(KeyWord)!=0){
-    KeyWord <- iconv(KeyWord, from="UTF-8")
-    browseURL(sprintf("http://www.google.com/search?q=%s",KeyWord))
   }
-}
-CaseNamesWidgetMenu$"Web Search"$Yahoo$handler <- function(h,...){
-  KeyWord <- svalue(.rqda$.CasesNamesWidget)
-  if (length(KeyWord)!=0){
-    KeyWord <- iconv(KeyWord, from="UTF-8")
-    browseURL(sprintf("http://search.yahoo.com/search;_ylt=A0oGkmFV.CZJNssAOK.l87UF?p=%s&ei=UTF-8&iscqry=&fr=sfp&fr2=sfp"
-                      ,KeyWord))
+
+  CaseNamesWidgetMenu[[gettext("Add New File to Selected Case", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    AddNewFileFunOfCase()
   }
-}
-CaseNamesWidgetMenu$"Web Search"$Baidu$handler <- function(h,...){
-  KeyWord <- svalue(.rqda$.CasesNamesWidget)
-  if (length(KeyWord)!=0){
-    KeyWord <- iconv(KeyWord, from="UTF-8",to="CP936") ## should be in CP936 to work properly.
-    browseURL(sprintf("http://www.baidu.com/s?wd=%s",paste("%",paste(charToRaw(KeyWord),sep="",collapse="%"),sep="",collapse="")))
+
+  CaseNamesWidgetMenu[[gettext("Case Memo", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      MemoWidget(gettext("Case", domain = "R-RQDA"),.rqda$.CasesNamesWidget,"cases")
+      ## see CodeCatButton.R  for definition of MemoWidget
+    }
   }
-}
-CaseNamesWidgetMenu$"Web Search"$Sogou$handler <- function(h,...){
-  KeyWord <- svalue(.rqda$.CasesNamesWidget)
-  if (length(KeyWord)!=0){
-    KeyWord <- iconv(KeyWord, from="UTF-8",to="CP936")## should be in CP936 to work properly.
-    browseURL(sprintf("http://www.sogou.com/sohu?query=%s",paste("%",paste(charToRaw(KeyWord),sep="",collapse="%"),sep="",collapse="")))
+  CaseNamesWidgetMenu[[gettext("Show Cases with Memo Only", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      cnames <- RQDAQuery("select name from cases where memo is not null")$name
+      if (!is.null(cnames)) cnames <- enc(cnames,"UTF-8")
+      .rqda$.CasesNamesWidget[] <- cnames
+    }
   }
+  CaseNamesWidgetMenu[[gettext("Add/modify Attributes...", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      SelectedCase <- svalue(.rqda$.CasesNamesWidget)
+      if (length(SelectedCase!=0)){
+        SelectedCase <- enc(SelectedCase,"UTF-8")
+        caseid <- dbGetQuery(.rqda$qdacon,sprintf("select id from cases where status=1 and name='%s'",SelectedCase))[,1]
+        CaseAttrFun(caseId=caseid,title=SelectedCase)
+      }
+  }}
+  CaseNamesWidgetMenu[[gettext("View Attributes", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      viewCaseAttr()
+    }
+  }
+  CaseNamesWidgetMenu[[gettext("Export Case Attributes", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      fName <- gfile(type='save',filter=list("csv"=list(pattern=c("*.csv"))))
+      Encoding(fName) <- "UTF-8"
+      if (length(grep(".csv$",fName))==0) fName <- sprintf("%s.csv",fName)
+      write.csv(GetAttr("case"), row.names=FALSE, file=fName, na="")
+    }
+  }
+  CaseNamesWidgetMenu[[gettext("Sort All by Created Time", domain = "R-RQDA")]]$handler <- function(h,...){
+    CaseNamesUpdate(.rqda$.CasesNamesWidget,sortByTime = TRUE)
+  }
+  CaseNamesWidgetMenu[[gettext("Web Search", domain = "R-RQDA")]]$Google$handler <- function(h,...){
+    KeyWord <- svalue(.rqda$.CasesNamesWidget)
+    if (length(KeyWord)!=0){
+      KeyWord <- iconv(KeyWord, from="UTF-8")
+      browseURL(sprintf("http://www.google.com/search?q=%s",KeyWord))
+    }
+  }
+  CaseNamesWidgetMenu[[gettext("Web Search", domain = "R-RQDA")]]$Yahoo$handler <- function(h,...){
+    KeyWord <- svalue(.rqda$.CasesNamesWidget)
+    if (length(KeyWord)!=0){
+      KeyWord <- iconv(KeyWord, from="UTF-8")
+      browseURL(sprintf("http://search.yahoo.com/search;_ylt=A0oGkmFV.CZJNssAOK.l87UF?p=%s&ei=UTF-8&iscqry=&fr=sfp&fr2=sfp"
+                        ,KeyWord))
+    }
+  }
+  CaseNamesWidgetMenu[[gettext("Web Search", domain = "R-RQDA")]]$Baidu$handler <- function(h,...){
+    KeyWord <- svalue(.rqda$.CasesNamesWidget)
+    if (length(KeyWord)!=0){
+      KeyWord <- iconv(KeyWord, from="UTF-8",to="CP936") ## should be in CP936 to work properly.
+      browseURL(sprintf("http://www.baidu.com/s?wd=%s",paste("%",paste(charToRaw(KeyWord),sep="",collapse="%"),sep="",collapse="")))
+    }
+  }
+  CaseNamesWidgetMenu[[gettext("Web Search", domain = "R-RQDA")]]$Sogou$handler <- function(h,...){
+    KeyWord <- svalue(.rqda$.CasesNamesWidget)
+    if (length(KeyWord)!=0){
+      KeyWord <- iconv(KeyWord, from="UTF-8",to="CP936")## should be in CP936 to work properly.
+      browseURL(sprintf("http://www.sogou.com/sohu?query=%s",paste("%",paste(charToRaw(KeyWord),sep="",collapse="%"),sep="",collapse="")))
+    }
+  }
+  CaseNamesWidgetMenu
 }
 
 
 ## pop-up menu of .rqda$.FileofCase
-FileofCaseWidgetMenu <- list() ## not used yet.
-FileofCaseWidgetMenu$"Add To File Category ..."$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    AddToFileCategory(Widget=.rqda$.FileofCase,updateWidget=FALSE)
+GetFileofCaseWidgetMenu <- function()
+{
+  FileofCaseWidgetMenu <- list() ## not used yet.
+  FileofCaseWidgetMenu[[gettext("Add To File Category ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      AddToFileCategory(Widget=.rqda$.FileofCase,updateWidget=FALSE)
+    }
   }
-}
-FileofCaseWidgetMenu$"Drop Selected File(s)"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    FileOfCat <- svalue(.rqda$.FileofCase)
-    if ((NumofSelected <- length(FileOfCat)) ==0) {
-      gmessage("Please select the Files you want to delete.",con=TRUE)} else
-    {
-      ## Give a confirm msg
-      del <- gconfirm(sprintf("Delete %i file(s) from this category. Are you sure?",NumofSelected),con=TRUE,icon="question")
-      if (isTRUE(del)){
-        SelectedCase <- svalue(.rqda$.CasesNamesWidget)
-        ## Encoding(SelectedCase) <- Encoding(FileOfCat)<- "UTF-8"
-        SelectedCase <- enc(SelectedCase,"UTF-8")
-        FileOfCat <- enc(FileOfCat,"UTF-8")
-        caseid <- dbGetQuery(.rqda$qdacon,sprintf("select id from cases where status=1 and name='%s'",SelectedCase))[,1]
-        for (i in FileOfCat){
-          fid <- dbGetQuery(.rqda$qdacon,sprintf("select id from source where status=1 and name='%s'",i))[,1]
-          dbGetQuery(.rqda$qdacon,sprintf("update caselinkage set status=0 where caseid=%i and fid=%i",caseid,fid))
+  FileofCaseWidgetMenu[[gettext("Drop Selected File(s)", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      FileOfCat <- svalue(.rqda$.FileofCase)
+      if ((NumofSelected <- length(FileOfCat)) ==0) {
+        gmessage(gettext("Please select the Files you want to delete.", domain = "R-RQDA"),con=TRUE)} else
+        {
+          ## Give a confirm msg
+          del <- gconfirm(sprintf(gettext("Delete %i file(s) from this category. Are you sure?", domain = "R-RQDA"),NumofSelected),con=TRUE,icon="question")
+          if (isTRUE(del)){
+            SelectedCase <- svalue(.rqda$.CasesNamesWidget)
+            ## Encoding(SelectedCase) <- Encoding(FileOfCat)<- "UTF-8"
+            SelectedCase <- enc(SelectedCase,"UTF-8")
+            FileOfCat <- enc(FileOfCat,"UTF-8")
+            caseid <- dbGetQuery(.rqda$qdacon,sprintf("select id from cases where status=1 and name='%s'",SelectedCase))[,1]
+            for (i in FileOfCat){
+              fid <- dbGetQuery(.rqda$qdacon,sprintf("select id from source where status=1 and name='%s'",i))[,1]
+              dbGetQuery(.rqda$qdacon,sprintf("update caselinkage set status=0 where caseid=%i and fid=%i",caseid,fid))
+            }
+            ## update Widget
+            UpdateFileofCaseWidget()
+          }
         }
-        ## update Widget
-        UpdateFileofCaseWidget()
+    }
+  }
+  FileofCaseWidgetMenu[[gettext("Delete Selected File(s)", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      SelectedFile <- svalue(.rqda$.FileofCase)
+      Encoding(SelectedFile) <- "UTF-8"
+      for (i in SelectedFile){
+        fid <- dbGetQuery(.rqda$qdacon, sprintf("select id from source where name='%s'",i))$id
+        dbGetQuery(.rqda$qdacon, sprintf("update source set status=0 where name='%s'",i))
+        dbGetQuery(.rqda$qdacon, sprintf("update caselinkage set status=0 where fid=%i",fid))
+        dbGetQuery(.rqda$qdacon, sprintf("update treefile set status=0 where fid=%i",fid))
+        dbGetQuery(.rqda$qdacon, sprintf("update coding set status=0 where fid=%i",fid))
+      }
+      .rqda$.FileofCase[] <- setdiff(.rqda$.FileofCase[],SelectedFile)
+    }
+  }
+  FileofCaseWidgetMenu[[gettext("Edit Selected File", domain = "R-RQDA")]]$handler <- function(h,...){
+    EditFileFun(FileNameWidget=.rqda$.FileofCase)
+  }
+  FileofCaseWidgetMenu[[gettext("File Memo", domain = "R-RQDA")]]$handler <- function(h,...){
+    MemoWidget(gettext("File", domain = "R-RQDA"),.rqda$.FileofCase,"source")
+  }
+  FileofCaseWidgetMenu[[gettext("Rename selected File", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      selectedFN <- svalue(.rqda$.FileofCase)
+      if (length(selectedFN)==0){
+        gmessage(gettext("Select a file first.", domain = "R-RQDA"),icon="error",con=TRUE)
+      }
+      else {
+        NewFileName <- ginput(gettext("Enter new file name. ", domain = "R-RQDA"),text=selectedFN, icon="info")
+        if (!is.na(NewFileName)) {
+          Encoding(NewFileName) <- "UTF-8"
+          rename(selectedFN,NewFileName,"source")
+          Fnames <- .rqda$.FileofCase[]
+          Fnames[Fnames==selectedFN] <- NewFileName
+          .rqda$.FileofCase[] <- Fnames
+        }
+  }}}
+  FileofCaseWidgetMenu[[gettext("Search Files within Seleted Case", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      pattern <- ifelse(is.null(.rqda$lastsearch),"file like '%%'",.rqda$lastsearch)
+      pattern <- ginput(gettext("Please input a search pattern.", domain = "R-RQDA"),text=pattern)
+      if (!is.na(pattern)){
+        Fid <- GetFileId("case")
+        tryCatch(SearchFiles(pattern,Fid=Fid,Widget=".FileofCase",is.UTF8=TRUE),error=function(e) gmessage(gettext("Error~~~.", domain = "R-RQDA")),con=TRUE)
+        assign("lastsearch",pattern,envir=.rqda)
       }
     }
   }
-}
-FileofCaseWidgetMenu$"Delete Selected File(s)"$handler <- function(h,...){
+  FileofCaseWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show All by Sorted by Imported Time", domain = "R-RQDA")]]$handler <- function(h,...){
+    ## UpdateFileofCaseWidget()
     if (is_projOpen(envir=.rqda,conName="qdacon")) {
-        SelectedFile <- svalue(.rqda$.FileofCase)
-        Encoding(SelectedFile) <- "UTF-8"
-        for (i in SelectedFile){
-            fid <- dbGetQuery(.rqda$qdacon, sprintf("select id from source where name='%s'",i))$id
-            dbGetQuery(.rqda$qdacon, sprintf("update source set status=0 where name='%s'",i))
-            dbGetQuery(.rqda$qdacon, sprintf("update caselinkage set status=0 where fid=%i",fid))
-            dbGetQuery(.rqda$qdacon, sprintf("update treefile set status=0 where fid=%i",fid))
-            dbGetQuery(.rqda$qdacon, sprintf("update coding set status=0 where fid=%i",fid))
-        }
-        .rqda$.FileofCase[] <- setdiff(.rqda$.FileofCase[],SelectedFile)
+      fid <- GetFileId(condition="case",type="all")
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCase,FileId=fid)
     }
-}
-FileofCaseWidgetMenu$"Edit Selected File"$handler <- function(h,...){
-  EditFileFun(FileNameWidget=.rqda$.FileofCase)
-}
-FileofCaseWidgetMenu$"File Memo"$handler <- function(h,...){
-  MemoWidget("File",.rqda$.FileofCase,"source")
-}
-FileofCaseWidgetMenu$"Rename selected File"$handler <- function(h,...){
+  }
+  FileofCaseWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Coded Files Only (sorted)", domain = "R-RQDA")]]$handler <- function(h,...){
     if (is_projOpen(envir=.rqda,conName="qdacon")) {
-        selectedFN <- svalue(.rqda$.FileofCase)
-        if (length(selectedFN)==0){
-            gmessage("Select a file first.",icon="error",con=TRUE)
-        }
-        else {
-            NewFileName <- ginput("Enter new file name. ",text=selectedFN, icon="info")
-            if (!is.na(NewFileName)) {
-                Encoding(NewFileName) <- "UTF-8"
-                rename(selectedFN,NewFileName,"source")
-                Fnames <- .rqda$.FileofCase[]
-                Fnames[Fnames==selectedFN] <- NewFileName
-                .rqda$.FileofCase[] <- Fnames
-            }
-        }}}
-FileofCaseWidgetMenu$"Search Files within Seleted Case"$handler <- function(h, ...) {
+      fid <- GetFileId(condition="case",type="coded")
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCase,FileId=fid)
+    }
+  }
+  FileofCaseWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Uncoded Files Only (sorted)", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      fid <- GetFileId(condition="case",type="uncoded")
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCase,FileId=fid)
+    }
+  }
+  FileofCaseWidgetMenu[[gettext("Show Selected File Property", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-        pattern <- ifelse(is.null(.rqda$lastsearch),"file like '%%'",.rqda$lastsearch)
-        pattern <- ginput("Please input a search pattern.",text=pattern)
-        if (!is.na(pattern)){
-            Fid <- GetFileId("case")
-            tryCatch(SearchFiles(pattern,Fid=Fid,Widget=".FileofCase",is.UTF8=TRUE),error=function(e) gmessage("Error~~~."),con=TRUE)
-            assign("lastsearch",pattern,envir=.rqda)
-        }
+      ShowFileProperty(Fid=GetFileId("case","selected"))
     }
-}
-FileofCaseWidgetMenu$"Show ..."$"Show All by Sorted by Imported Time"$handler <- function(h,...){
-  ## UpdateFileofCaseWidget()
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-    fid <- GetFileId(condition="case",type="all")
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCase,FileId=fid)
   }
-}
-FileofCaseWidgetMenu$"Show ..."$"Show Coded Files Only (sorted)"$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-    fid <- GetFileId(condition="case",type="coded")
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCase,FileId=fid)
-  }
-}
-FileofCaseWidgetMenu$"Show ..."$"Show Uncoded Files Only (sorted)"$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-    fid <- GetFileId(condition="case",type="uncoded")
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCase,FileId=fid)
-  }
-}
-FileofCaseWidgetMenu$"Show Selected File Property"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    ShowFileProperty(Fid=GetFileId("case","selected"))
-    }
+  FileofCaseWidgetMenu
 }
 
 ####################
 ## Defunct functions
 ####################
 
-##   AddWebSearchButton <- function(label="WebSearch",CaseNamesWidget=.rqda$.CasesNamesWidget){
+##   AddWebSearchButton <- function(label=gettext("WebSearch", domain = "R-RQDA"),CaseNamesWidget=.rqda$.CasesNamesWidget){
 ##     gbutton(label,handler=function(h,...) {
 ##       if (is_projOpen(envir=.rqda,conName="qdacon")) {
 ##         KeyWord <- svalue(CaseNamesWidget)
@@ -432,14 +440,14 @@ FileofCaseWidgetMenu$"Show Selected File Property"$handler <- function(h, ...) {
 ## }
 
 
-## CaseMemoButton <- function(label="Memo",...){
+## CaseMemoButton <- function(label=gettext("Memo", domain = "R-RQDA"),...){
 ## ## no longer used
 ##   gbutton(label, handler=function(h,...) {
 ##     ## code memo: such as meaning of code etc.
 ##     if (is_projOpen(envir=.rqda,"qdacon")) {
 ##       currentCase <- svalue(.rqda$.CasesNamesWidget)
 ##       if (length(currentCase)==0){
-##         gmessage("Select a Case first.",icon="error",con=TRUE)
+##         gmessage(gettext("Select a Case first.", domain = "R-RQDA"),icon="error",con=TRUE)
 ##       }
 ##       else {
 ##         tryCatch(dispose(.rqda$.casememo),error=function(e) {})
@@ -448,7 +456,7 @@ FileofCaseWidgetMenu$"Show Selected File Property"$handler <- function(h, ...) {
 ##         .casememo <- .rqda$.casememo
 ##         .casememo2 <- gpanedgroup(horizontal = FALSE, con=.casememo)
 ##         currentCase <- enc(currentCase, encoding="UTF-8")
-##         gbutton("Save Case Memo",con=.casememo2,handler=function(h,...){
+##         gbutton(gettext("Save Case Memo", domain = "R-RQDA"),con=.casememo2,handler=function(h,...){
 ##           newcontent <- svalue(W)
 ##           ## Encoding(newcontent) <- "UTF-8"
 ##           newcontent <- enc(newcontent,encoding="UTF-8") ## take care of double quote.

--- a/R/CaseFun.R
+++ b/R/CaseFun.R
@@ -65,7 +65,7 @@ AddFileToCaselinkage <- function(Widget=.rqda$.fnames_rqda){
                   ## write only when the selected file associated with specific case is not in the caselinkage table
                   DAT <- data.frame(caseid=caseid, fid=fid[!fid %in% exist$fid], selfirst=0, selend=selend[!fid %in% exist$fid], status=1,owner=.rqda$owner,data=date(),memo='')
                   success <- dbWriteTable(.rqda$qdacon,"caselinkage",DAT,row.name=FALSE,append=TRUE)
-                  if (!success) gmessage(sprintf("Fail to write to database for case with id %i", i))
+                  if (!success) gmessage(sprintf(gettext("Fail to write to database for case with id %i", domain = "R-RQDA"), i))
               }}
       }
       ## CurrentFrame <- sys.frame(sys.nframe())
@@ -80,7 +80,7 @@ AddFileToCaselinkage <- function(Widget=.rqda$.fnames_rqda){
       ##       DAT <- data.frame(caseid=caseid, fid=fid[!fid %in% exist$fid], selfirst=0, selend=selend[!fid %in% exist$fid], status=1,owner=.rqda$owner,data=date(),memo='')
       ##       success <- dbWriteTable(.rqda$qdacon,"caselinkage",DAT,row.name=FALSE,append=TRUE)
       ##       ## write to caselinkage table
-      ##       if (!success) gmessage("Fail to write to database.")
+      ##       if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
       ##     }
       ##   }
       ## }

--- a/R/CodeCatButton.R
+++ b/R/CodeCatButton.R
@@ -35,9 +35,9 @@ AddTodbTable <- function(item,dbTable,Id="id",field="name",con=.rqda$qdacon,...)
 
 
 #################
-AddCodeCatButton <- function(label="ADD"){
+AddCodeCatButton <- function(label=gettext("ADD", domain = "R-RQDA")){
     AddCodCatB <- gbutton(label,handler=function(h,...) {
-        item <- ginput("Enter new Code Category. ", icon="info")
+        item <- ginput(gettext("Enter new Code Category. ", domain = "R-RQDA"), icon="info")
         if (!is.na(item)){
             Encoding(item) <- "UTF-8"
             AddTodbTable(item,"codecat",Id="catid") ## CODE CATegory
@@ -51,10 +51,10 @@ AddCodeCatButton <- function(label="ADD"){
 
 
 
-DeleteCodeCatButton <- function(label="Delete")
+DeleteCodeCatButton <- function(label=gettext("Delete", domain = "R-RQDA"))
 {
     DelCodCatB <- gbutton(label, handler=function(h,...) {
-        del <- gconfirm("Really delete the Code Category?",icon="question")
+        del <- gconfirm(gettext("Really delete the Code Category?", domain = "R-RQDA"),icon="question")
         if (isTRUE(del)){
             Selected <- svalue(.rqda$.CodeCatWidget)
             Encoding(Selected) <- "UTF-8"
@@ -66,7 +66,7 @@ DeleteCodeCatButton <- function(label="Delete")
                 tryCatch(dbGetQuery(.rqda$qdacon,sprintf("update treecode set status=0 where catid='%s'",catid)),error=function(e){})
                 ## should delete all the related codelists
                 UpdateCodeofCatWidget() ## update the code of cat widget
-            } else gmessage("The Category Name is not unique.",container=TRUE)
+            } else gmessage(gettext("The Category Name is not unique.", domain = "R-RQDA"),container=TRUE)
         }
     }
                           )
@@ -76,17 +76,17 @@ DeleteCodeCatButton <- function(label="Delete")
 }
 
 
-CodeCat_RenameButton <- function(label="Rename",Widget=.rqda$.CodeCatWidget,...)
+CodeCat_RenameButton <- function(label=gettext("Rename", domain = "R-RQDA"),Widget=.rqda$.CodeCatWidget,...)
 {
   ## rename of selected code cat.
   CodCatRenB <- gbutton(label,handler=function(h,...) {
       OldName <- svalue(Widget)
       if (length(OldName)==0){
-          gmessage("Select a Code Category first.",icon="error",container=TRUE)
+          gmessage(gettext("Select a Code Category first.", domain = "R-RQDA"),icon="error",container=TRUE)
       }
       else {
           ## get the new file names
-          NewName <- ginput("Enter new Cateory name. ", text=OldName, icon="info")
+          NewName <- ginput(gettext("Enter new Cateory name. ", domain = "R-RQDA"), text=OldName, icon="info")
           if (!is.na(NewName)) {
               Encoding(NewName) <- "UTF-8"
               rename(OldName,NewName,"codecat")
@@ -121,7 +121,7 @@ UpdateCodeofCatWidget <- function(con=.rqda$qdacon,Widget=.rqda$.CodeofCat,sort=
     tryCatch(Widget[] <- items,error=function(e){})
 }
 
-CodeCatAddToButton <- function(label="Add To",Widget=.rqda$.CodeCatWidget,...)
+CodeCatAddToButton <- function(label=gettext("Add To", domain = "R-RQDA"),Widget=.rqda$.CodeCatWidget,...)
 {
     ans <- gbutton(label,handler=function(h,...) {
         ## SelectedCodeCat and its id (table codecat): svalue()-> Name; sql->catid
@@ -130,7 +130,7 @@ CodeCatAddToButton <- function(label="Add To",Widget=.rqda$.CodeCatWidget,...)
         ## CodeList and the id (table freecode): sql -> name and id where status=1
         freecode <-  dbGetQuery(.rqda$qdacon,"select name, id from freecode where status=1")
         if (nrow(freecode) == 0){
-            gmessage("No free codes yet.",cont=.rqda$.CodeCatWidget)
+            gmessage(gettext("No free codes yet.", domain = "R-RQDA"),cont=.rqda$.CodeCatWidget)
         } else {
             Encoding(SelectedCodeCat) <- Encoding(freecode[['name']]) <- "UTF-8"
             ## Get CodeList already in the category (table treecode): sql -> cid where catid==catid
@@ -150,7 +150,7 @@ CodeCatAddToButton <- function(label="Add To",Widget=.rqda$.CodeCatWidget,...)
                 UpdateCodeofCatWidget()
             }
         }})
-    gtkWidgetSetTooltipText(getToolkitWidget(ans),"Add code(s) to the selected code category.")
+    gtkWidgetSetTooltipText(getToolkitWidget(ans),gettext("Add code(s) to the selected code category.", domain = "R-RQDA"))
     assign("CodCatAddToB",ans, envir=button)
     enabled(ans) <- FALSE
     return(ans)
@@ -158,16 +158,16 @@ CodeCatAddToButton <- function(label="Add To",Widget=.rqda$.CodeCatWidget,...)
 
   ## update .rqda$.CodeofCat[] by click handler on .rqda$.CodeCatWidget
 
-CodeCatDropFromButton <- function(label="Drop From",Widget=.rqda$.CodeofCat,...)
+CodeCatDropFromButton <- function(label=gettext("Drop From", domain = "R-RQDA"),Widget=.rqda$.CodeofCat,...)
 {
     ans <- gbutton(label,handler=function(h,...) {
         ## Get CodeList already in the category (table treecode): svalue()
         CodeOfCat <- svalue(Widget)
         if ((NumofSelected <- length(CodeOfCat)) ==0) {
-            gmessage("Please select the Codes you want to delete.",container=TRUE)
+            gmessage(gettext("Please select the Codes you want to delete.", domain = "R-RQDA"),container=TRUE)
         } else {
             ## Give a confirm msg
-            del <- gconfirm(sprintf("Delete %i code(s) from this category. Are you sure?",NumofSelected),container=TRUE,icon="question")
+            del <- gconfirm(sprintf(gettext("Delete %i code(s) from this category. Are you sure?", domain = "R-RQDA"),NumofSelected),container=TRUE,icon="question")
             if (isTRUE(del)){
                 ## set status==0 for those selected CodeList (table treecode)
                 SelectedCodeCat <- svalue(.rqda$.CodeCatWidget)
@@ -183,16 +183,16 @@ CodeCatDropFromButton <- function(label="Drop From",Widget=.rqda$.CodeofCat,...)
         }
     }
                    )
-    gtkWidgetSetTooltipText(getToolkitWidget(ans),"Drop selected code(s) from code category.")
+    gtkWidgetSetTooltipText(getToolkitWidget(ans),gettext("Drop selected code(s) from code category.", domain = "R-RQDA"))
     assign("CodCatADroFromB",ans, envir=button)
     enabled(ans) <- FALSE
     return(ans)
     return(ans)
 }
 
-CodeCatMemoButton <- function(label="Memo",...){
+CodeCatMemoButton <- function(label=gettext("Memo", domain = "R-RQDA"),...){
     CodCatMemB <- gbutton(label,handler=function(h,...) {
-        MemoWidget("Code Category",.rqda$.CodeCatWidget,"codecat")
+        MemoWidget(gettext("Code Category", domain = "R-RQDA"),.rqda$.CodeCatWidget,"codecat")
         }
                           )
     assign("CodCatMemB", CodCatMemB,envir=button)
@@ -252,85 +252,92 @@ where coding2.status=1 and source.status=1 and freecode.status=1 and coding2.cid
     ## class(ct) <- c("codingsByOne", "data.frame")
     ct
 }
-
-CodeCatWidgetMenu <- list()
-CodeCatWidgetMenu$"Add New Code to Selected Category"$handler <- function(h,...) {
+GetCodeCatWidgetMenu <- function()
+{
+  CodeCatWidgetMenu <- list()
+  CodeCatWidgetMenu[[gettext("Add New Code to Selected Category", domain = "R-RQDA")]]$handler <- function(h,...) {
     if (is_projOpen(envir=.rqda,conName="qdacon")) {
-        codename <- ginput("Enter new code. ", icon="info")
-        if (!is.na(codename)){
-            codename <- enc(codename,encoding="UTF-8")
-            addcode(codename)
-            CodeNamesUpdate(sortByTime=FALSE)
-            cid <- RQDAQuery(sprintf("select id from freecode where status=1 and name='%s'",codename))$id
-            ## end of add a new code to free code.
-            SelectedCodeCat <- svalue(.rqda$.CodeCatWidget)
-            if (length(SelectedCodeCat)==0) {gmessage("Select a code category first.",container=TRUE)} else{
-                catid <- dbGetQuery(.rqda$qdacon,sprintf("select catid from codecat where status=1 and name='%s'",SelectedCodeCat))[,1]
-                ## CodeList and the id (table freecode): sql -> name and id where status==1
-                Dat <- data.frame(cid=cid,catid=catid,date=date(),dateM=date(),memo="",
-                                  status=1, owner=.rqda$owner)
-                ## Push selected codeList to table treecode
-                ok <- dbWriteTable(.rqda$qdacon,"treecode",Dat,row.names=FALSE,append=TRUE)
-                if (ok) {
-                ## update .CodeofCat Widget
-                    UpdateCodeofCatWidget()
-                } else gmessage("Failed to assign code category")
-            }
+      codename <- ginput(gettext("Enter new code. ", domain = "R-RQDA"), icon="info")
+      if (!is.na(codename)){
+        codename <- enc(codename,encoding="UTF-8")
+        addcode(codename)
+        CodeNamesUpdate(sortByTime=FALSE)
+        cid <- RQDAQuery(sprintf("select id from freecode where status=1 and name='%s'",codename))$id
+        ## end of add a new code to free code.
+        SelectedCodeCat <- svalue(.rqda$.CodeCatWidget)
+        if (length(SelectedCodeCat)==0) {gmessage(gettext("Select a code category first.", domain = "R-RQDA"),container=TRUE)} else{
+          catid <- dbGetQuery(.rqda$qdacon,sprintf("select catid from codecat where status=1 and name='%s'",SelectedCodeCat))[,1]
+          ## CodeList and the id (table freecode): sql -> name and id where status==1
+          Dat <- data.frame(cid=cid,catid=catid,date=date(),dateM=date(),memo="",
+                            status=1, owner=.rqda$owner)
+          ## Push selected codeList to table treecode
+          ok <- dbWriteTable(.rqda$qdacon,"treecode",Dat,row.names=FALSE,append=TRUE)
+          if (ok) {
+            ## update .CodeofCat Widget
+            UpdateCodeofCatWidget()
+          } else gmessage(gettext("Failed to assign code category", domain = "R-RQDA"))
         }
+      }
     }
-}
-CodeCatWidgetMenu$"Codings of selected category"$handler <- function(h,...){
+  }
+  CodeCatWidgetMenu[[gettext("Codings of selected category", domain = "R-RQDA")]]$handler <- function(h,...){
     if (is_projOpen(envir=.rqda,conName="qdacon")) {
-        ct <- getCodingsByCategory(fid=getFileIds(condition=.rqda$TOR))
-        print.codingsByOne(ct)
+      ct <- getCodingsByCategory(fid=getFileIds(condition=.rqda$TOR))
+      print.codingsByOne(ct)
     }
-}
-CodeCatWidgetMenu$Memo$handler <- function(h,...){
- if (is_projOpen(envir=.rqda,conName="qdacon")) {
- MemoWidget("Code Category",.rqda$.CodeCatWidget,"codecat")
-}
-}
-##psccFun <- function(h,...){
-##    plotCodeCategory()
-##}
-##psccItem <- gaction("Plot Selected Code Category", handler=psccFun,toolkit=guiToolkit("RGtk2"))
-## need to manually set the toolkit
-##CodeCatWidgetMenu$"Plot Selected Code Category" <- psccItem
-CodeCatWidgetMenu$"Plot Selected Code Categories"$handler <- function(h,...){plotCodeCategory()}
-CodeCatWidgetMenu$"Plot Selected Code Categories with d3"$handler <- function(h,...){d3CodeCategory()}
+  }
+  CodeCatWidgetMenu[[gettext("Memo", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      MemoWidget("Code Category",.rqda$.CodeCatWidget,"codecat")
+    }
+  }
+  ##psccFun <- function(h,...){
+  ##    plotCodeCategory()
+  ##}
+  ##psccItem <- gaction("Plot Selected Code Category", handler=psccFun,toolkit=guiToolkit("RGtk2"))
+  ## need to manually set the toolkit
+  ##CodeCatWidgetMenu$"Plot Selected Code Category" <- psccItem
+  CodeCatWidgetMenu[[gettext("Plot Selected Code Categories", domain = "R-RQDA")]]$handler <- function(h,...){plotCodeCategory()}
+  CodeCatWidgetMenu[[gettext("Plot Selected Code Categories with d3", domain = "R-RQDA")]]$handler <- function(h,...){d3CodeCategory()}
 
-CodeCatWidgetMenu$"Sort by created time"$handler <- function(h,...){
- if (is_projOpen(envir=.rqda,conName="qdacon")) {
-   UpdateTableWidget(Widget=.rqda$.CodeCatWidget,FromdbTable="codecat")
-   ## UpdateCodeofCatWidget() ## wrong function
-}
+  CodeCatWidgetMenu[[gettext("Sort by created time", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      UpdateTableWidget(Widget=.rqda$.CodeCatWidget,FromdbTable="codecat")
+      ## UpdateCodeofCatWidget() ## wrong function
+    }
+  }
+  CodeCatWidgetMenu
 }
 
 
 ##
-CodeofCatWidgetMenu <- list()
-CodeofCatWidgetMenu$"Rename Selected Code"$handler <- function(h, ...) {
-  selectedCodeName <- svalue(.rqda$.CodeofCat)
-  if (length(selectedCodeName)==0){
-    gmessage("Select a code first.",icon="error",container=TRUE)
-  }
-  else {
-    NewCodeName <- ginput("Enter new code name. ", text=selectedCodeName, icon="info")
-    if (!is.na(NewCodeName)) {
-      Encoding(NewCodeName) <- Encoding(selectedCodeName) <- "UTF-8"
-      rename(selectedCodeName,NewCodeName,"freecode")
-      UpdateWidget(".codes_rqda",from=selectedCodeName,to=NewCodeName)
-      UpdateWidget(".CodeofCat",from=selectedCodeName,to=NewCodeName)
+GetCodeofCatWidgetMenu <- function()
+{
+  CodeofCatWidgetMenu <- list()
+  CodeofCatWidgetMenu[[gettext("Rename Selected Code", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    selectedCodeName <- svalue(.rqda$.CodeofCat)
+    if (length(selectedCodeName)==0){
+      gmessage(gettext("Select a code first.", domain = "R-RQDA"),icon="error",container=TRUE)
+    }
+    else {
+      NewCodeName <- ginput(gettext("Enter new code name. ", domain = "R-RQDA"), text=selectedCodeName, icon="info")
+      if (!is.na(NewCodeName)) {
+        Encoding(NewCodeName) <- Encoding(selectedCodeName) <- "UTF-8"
+        rename(selectedCodeName,NewCodeName,"freecode")
+        UpdateWidget(".codes_rqda",from=selectedCodeName,to=NewCodeName)
+        UpdateWidget(".CodeofCat",from=selectedCodeName,to=NewCodeName)
+      }
     }
   }
-}
-CodeofCatWidgetMenu$"Code Memo"$handler <- function(h, ...) {
+  CodeofCatWidgetMenu[[gettext("Code Memo", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    MemoWidget("Code",.rqda$.CodeofCat,"freecode")
+      MemoWidget(gettext("Code", domain = "R-RQDA"),.rqda$.CodeofCat,"freecode")
     }
   }
-CodeofCatWidgetMenu$"Sort by created time"$handler <- function(h,...){
- if (is_projOpen(envir=.rqda,conName="qdacon")) {
- UpdateCodeofCatWidget()
-}
+  CodeofCatWidgetMenu[[gettext("Sort by created time", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      UpdateCodeofCatWidget()
+    }
+  }
+  CodeofCatWidgetMenu
 }

--- a/R/CodesFun.R
+++ b/R/CodesFun.R
@@ -31,7 +31,7 @@ CodeNamesUpdate <- function(CodeNamesWidget=.rqda$.codes_rqda,sortByTime=TRUE,de
     }
   }
   tryCatch(CodeNamesWidget[] <- codeName, error=function(e){})
-  } else gmessage("Cannot update Code List in the Widget. Project is closed already.\n",con=TRUE)
+  } else gmessage(gettext("Cannot update Code List in the Widget. Project is closed already.\n", domain = "R-RQDA"),con=TRUE)
 }
 
 
@@ -49,7 +49,7 @@ CodeNamesWidgetUpdate <- function(CodeNamesWidget=.rqda$.codes_rqda,sortByTime=T
       }
     }
     tryCatch(CodeNamesWidget[] <- codeName, error=function(e){})
-  } else gmessage("Cannot update Code List in the Widget. Project is closed already.\n",con=TRUE)
+  } else gmessage(gettext("Cannot update Code List in the Widget. Project is closed already.\n", domain = "R-RQDA"),con=TRUE)
 }
 
 mark <- function(widget,fore.col=.rqda$fore.col,back.col=NULL,addButton=FALSE,buttonLabel="",codingTable="coding"){
@@ -209,7 +209,7 @@ InsertAnchor <- function(widget,label,index,label.col="gray90",
                   assign(".codingmemo",.codingmemo, envir=.rqda)
                   .codingmemo <- get(".codingmemo",envir=.rqda)
                   .codingmemo2 <- gpanedgroup(horizontal = FALSE, container=.codingmemo)
-                  .codingMemoSaveButton <- gbutton("Save Coding Memo",container=.codingmemo2,action=list(rowid=rowid),handler=function(h,...){
+                  .codingMemoSaveButton <- gbutton(gettext("Save Coding Memo", domain = "R-RQDA"),container=.codingmemo2,action=list(rowid=rowid),handler=function(h,...){
                       newcontent <- svalue(.rqda$.cdmemocontent)
                       newcontent <- enc(newcontent,encoding="UTF-8") ## take care of double quote.
                       RQDAQuery(sprintf("update coding set memo='%s' where rowid=%s",newcontent,rowid=h$action$rowid))
@@ -323,12 +323,22 @@ retrieval <- function(Fid=NULL,order=c("fname","ftime","ctime"),CodeNameWidget=.
     } else {
       retrieval <- RQDAQuery(sprintf("select cid,fid, selfirst, selend, seltext, %s.rowid,source.name,source.id from %s,source where %s.status=1 and cid=%i and source.id=fid and fid in (%s) %s",codingTable, codingTable, codingTable, currentCid, paste(Fid,collapse=","), order))
     }
-    if (nrow(retrieval)==0) gmessage("No Coding associated with the selected code.",container=TRUE) else {
+    if (nrow(retrieval)==0) gmessage(gettext("No Coding associated with the selected code.", domain = "R-RQDA"),container=TRUE) else {
       fid <- unique(retrieval$fid)
       retrieval$fname <-""
       Nfiles <- length(fid)
       Ncodings <- nrow(retrieval)
-      title <- sprintf(ngettext(Ncodings,"%i Retrieved coding: \"%s\" from %s %s","%i Retrieved codings: \"%s\" from %s %s"),Ncodings,currentCode2,Nfiles,ngettext(Nfiles,"file","files"))
+      if(Ncodings == 1){
+          title <- sprintf(ngettext(Nfiles,
+                                    "1 retrieved coding: \"%s\" from %i file",
+                                    "1 retrieved coding: \"%s\" from %i files", domain = "R-RQDA"),
+                           currentCode2,Nfiles)
+      } else {
+          title <- sprintf(ngettext(Nfiles,
+                                    "%i retrieved codings: \"%s\" from %i file",
+                                    "%i retrieved codings: \"%s\" from %i files", domain = "R-RQDA"),
+                           Ncodings,currentCode2,Nfiles)
+      }
       tryCatch(eval(parse(text=sprintf("dispose(.rqda$.codingsOf%s)",currentCid))),error=function(e){})
       wnh <- size(.rqda$.root_rqdagui) ## size of the main window
       .gw <- gwindow(title=title, parent=c(wnh[1]+10,2),
@@ -386,9 +396,9 @@ retrieval <- function(Fid=NULL,order=c("fname","ftime","ctime"),CodeNameWidget=.
           Exists <- RQDAQuery(sprintf("select * from coding where cid=%s and selfirst=%s and selend=%s and status=1", currentCid, DAT$selfirst, DAT$selend))
           if (nrow(Exists)==0) {
           success <- is.null(try(RQDAQuery(sprintf("insert into %s (cid,fid, seltext, selfirst, selend, status, owner, date) values (%s, %s, '%s', %s, %s, %s, '%s', '%s') ", codingTable, currentCid, DAT$fid, DAT$seltext, DAT$selfirst, DAT$selend, 1, .rqda$owner, as.character(date()))),silent=TRUE))
-          if (!success) gmessage("cannot recode this text segment.", type="warning") else{
+          if (!success) gmessage(gettext("cannot recode this text segment.", domain = "R-RQDA"), type="warning") else{
             freq <- RQDAQuery(sprintf("select count(cid) as freq from coding where status=1 and cid=%s", currentCid))$freq
-            names(CodeNameWidget) <- sprintf("Selected code id is %s__%s codings",currentCid, freq)
+            names(CodeNameWidget) <- sprintf(gettext("Selected code id is %s__%s codings", domain = "R-RQDA"),currentCid, freq)
           }
           }
         }
@@ -400,7 +410,7 @@ retrieval <- function(Fid=NULL,order=c("fname","ftime","ctime"),CodeNameWidget=.
       RecodeFun <- function(widget, event, ...){
         RQDAQuery(sprintf("update %s set status=-1 where rowid=%s", .rqda$codingTable, rowid))
         freq <- RQDAQuery(sprintf("select count(cid) as freq from coding where status=1 and cid=%s", currentCid))$freq
-        names(CodeNameWidget) <- sprintf("Selected code id is %s__%s codings",currentCid, freq)
+        names(CodeNameWidget) <- sprintf(gettext("Selected code id is %s__%s codings", domain = "R-RQDA"),currentCid, freq)
       }
       RecodeFun
       } ## end of ComputeUnMarkFun
@@ -418,7 +428,7 @@ retrieval <- function(Fid=NULL,order=c("fname","ftime","ctime"),CodeNameWidget=.
         anchorcreated <- buffer$createChildAnchor(iter)
         iter$BackwardChar()
         anchor <- iter$getChildAnchor()
-        lab <- gtkLabelNew("Back")
+        lab <- gtkLabelNew(gettext("Back", domain = "R-RQDA"))
         widget <- gtkEventBoxNew()
         widget$Add(lab)
         gSignalConnect(widget, "button-press-event",
@@ -429,7 +439,7 @@ retrieval <- function(Fid=NULL,order=c("fname","ftime","ctime"),CodeNameWidget=.
         buffer$createChildAnchor(iter)
         iter$BackwardChar()
         anchor_recode <- iter$getChildAnchor()
-        lab_recode <- gtkLabelNew("Recode")
+        lab_recode <- gtkLabelNew(gettext("Recode", domain = "R-RQDA"))
         widget_recode <- gtkEventBoxNew()
         widget_recode$Add(lab_recode)
         gSignalConnect(widget_recode, "button-press-event",
@@ -440,7 +450,7 @@ retrieval <- function(Fid=NULL,order=c("fname","ftime","ctime"),CodeNameWidget=.
         buffer$createChildAnchor(iter)
         iter$BackwardChar()
         anchor_unmark <- iter$getChildAnchor()
-        lab_unmark<- gtkLabelNew("Unmark")
+        lab_unmark<- gtkLabelNew(gettext("Unmark", domain = "R-RQDA"))
         widget_unmark <- gtkEventBoxNew()
         widget_unmark$Add(lab_unmark)
         gSignalConnect(widget_unmark, "button-press-event",
@@ -473,7 +483,7 @@ ExportCodingOfOneCode <- function(file,currentCode,Fid,order=c("fname","ftime","
    ## } else {
     retrieval <- RQDAQuery(sprintf("select cid,fid, selfirst, selend, seltext, %s.rowid,source.name,source.id from %s,source where %s.status=1 and cid=%i and source.id=coding.fid and fid in (%s) %s",codingTable,codingTable,codingTable,currentCid, paste(Fid,collapse=","), order))
 ##    }
-    if (nrow(retrieval)==0) gmessage(sprintf("No Coding associated with the '%s'.",currentCode),container=TRUE) else {
+    if (nrow(retrieval)==0) gmessage(sprintf(gettext("No Coding associated with the '%s'.", domain = "R-RQDA"),currentCode),container=TRUE) else {
       fid <- unique(retrieval$fid)
       retrieval$fname <-""
       for (i in fid){
@@ -490,16 +500,26 @@ ExportCodingOfOneCode <- function(file,currentCode,Fid,order=c("fname","ftime","
       Ncodings <- nrow(retrieval)
       Encoding(retrieval$seltext) <- "UTF-8"
       if (nrow(retrieval)==1) {
-        cat(sprintf("<hr><p align='center'><b><font color='blue' size='+2'>%i Coding of <a id='%s'>\"%s\" from %s %s </a></b></font><hr><p align='left'>",Ncodings,currentCode,currentCode,Nfiles,ngettext(Nfiles,"file","files")),file=file,append=append)
+       cat("<hr><p align='center'><b><font color='blue' size='+2'>",
+           sprintf(ngettext(Nfiles,
+                            "%i Coding of <a id='%s'>\"%s\"</a> from %s file.",
+                            "%i Coding of <a id='%s'>\"%s\"</a> from %s files.", domain = "R-RQDA"),
+                   Ncodings,currentCode,currentCode,Nfiles),
+           "</b></font><hr><p align='left'>", sep="",file=file,append=append)
      } else {
-       cat(sprintf("<hr><p align='center'><b><font color='blue' size='+2'>%i Codings of <a id='%s'>\"%s\"</a> from %s %s.</b></font><hr><p align='left'>",Ncodings,currentCode,currentCode,Nfiles,ngettext(Nfiles,"file","files")),file=file,append=append)
+       cat("<hr><p align='center'><b><font color='blue' size='+2'>",
+           sprintf(ngettext(Nfiles,
+                            "%i Codings of <a id='%s'>\"%s\"</a> from %s file.",
+                            "%i Codings of <a id='%s'>\"%s\"</a> from %s files.", domain = "R-RQDA"),
+                   Ncodings,currentCode,currentCode,Nfiles),
+           "</b></font><hr><p align='left'>", sep="",file=file,append=append)
       }
       retrieval$seltext <- gsub("\\n", "<p>", retrieval$seltext)
       apply(retrieval,1, function(x){
         metaData <- sprintf("<b><font color='red'> %s [%s:%s] </font></b><br><br>",x[['fname']],x[['selfirst']],x[['selend']])
         cat(metaData,file=file,append=TRUE)
         cat(x[['seltext']],file=file,append=TRUE)
-        cat(sprintf("<br><a href='#%s+b'>Back<a><br><br>",currentCode),file=file,append=TRUE)
+        cat(sprintf("<br><a href='#%s+b'>", currentCode), gettext("Back", domain = "R-RQDA"), "<a><br><br>", sep="",file=file,append=TRUE)
       }
             )## end of apply
     }}}## end of export helper function
@@ -536,7 +556,7 @@ ClickHandlerFun <- function(CodeNameWidget,buttons=c("MarCodB1","UnMarB1"),codin
         SelectedCode <- currentCode <- enc(currentCode,encoding="UTF-8")
         currentCid <- dbGetQuery(con,sprintf("select id from freecode where name='%s'",SelectedCode))[,1]
        freq <- RQDAQuery(sprintf("select count(cid) as freq from coding where status=1 and cid=%s", currentCid))$freq
-        names(CodeNameWidget) <- sprintf("Selected code id is %s__%s codings",currentCid, freq)
+        names(CodeNameWidget) <- sprintf(gettext("Selected code id is %s__%s codings", domain = "R-RQDA"),currentCid, freq)
         if (exists(".root_edit",envir=.rqda) && isExtant(.rqda$.root_edit)) { ## a file is open
             for (i in buttons) {
                 b <- get(i,envir=button)
@@ -621,7 +641,7 @@ NextRowId <- function(table){
   ans
 }
 
-InsertAnnotation <- function (index,fid,rowid,label="[Annotation]",AnchorPos=NULL)
+InsertAnnotation <- function (index,fid,rowid,label=gettext("[Annotation]", domain = "R-RQDA"),AnchorPos=NULL)
   {
     widget=.rqda$.openfile_gui
     lab <- gtkLabelNew(label)
@@ -659,7 +679,7 @@ DeleteAnnotationAnchorByMark <- function(markname){
 openAnnotation <- function(New=TRUE,pos,fid,rowid,AnchorPos=NULL){
     tryCatch(dispose(.rqda$.annotation),error=function(e) {})
     wnh <- size(.rqda$.root_rqdagui)
-    .annotation <- gwindow(title="Annotation",parent=c(wnh[1]+10,2),
+    .annotation <- gwindow(title=ngettext(1, "Annotation", "Annotations", domain = "R-RQDA"),parent=c(wnh[1]+10,2), # ngettext avoid update_pkg_po() crash.
                            width = min(c(gdkScreenWidth()- wnh[1]-20,getOption("widgetSize")[1])),
                            height = min(c(wnh[2],getOption("widgetSize")[2]))
                            )
@@ -668,7 +688,7 @@ openAnnotation <- function(New=TRUE,pos,fid,rowid,AnchorPos=NULL){
     assign(".annotation",.annotation, envir=.rqda)
     .annotation2 <- gpanedgroup(horizontal = FALSE, container=.annotation)
     savAnnB <-
-    gbutton("Save Annotation",container=.annotation2,handler=function(h,...){
+    gbutton(gettext("Save Annotation", domain = "R-RQDA"),container=.annotation2,handler=function(h,...){
         newcontent <- svalue(W)
         newcontent <- enc(newcontent,encoding="UTF-8")
         if (newcontent != ""){
@@ -713,7 +733,7 @@ Annotation <- function(...){
     W <- tryCatch( get(".openfile_gui",envir=.rqda), error=function(e){})
     ## get the widget for file display. If it does not exist, then return NULL.
     pos <- tryCatch(sindex(W,includeAnchor=FALSE),error=function(e) {}) ## if the not file is open, it doesn't work.
-    if (is.null(pos)) {gmessage("Open a file first!",container=TRUE)}
+    if (is.null(pos)) {gmessage(gettext("Open a file first!", domain = "R-RQDA"),container=TRUE)}
     else {
       AnchorPos <- sindex(W,includeAnchor=TRUE)$startN
       SelectedFile <- svalue(.rqda$.root_edit)
@@ -765,7 +785,7 @@ AddToCodeCategory <- function (Widget = .rqda$.codes_rqda, updateWidget = TRUE)
   Encoding(query$name) <- "UTF-8"
   CodeCat <- RQDAQuery(sprintf("select name, catid from codecat where status=1 and catid not in (select catid from treecode where status=1 and cid in (%s) group by catid)", paste("'", cid, "'", sep = "", collapse = ",")))
   if (nrow(CodeCat) == 0) {
-    gmessage("Add Code Categroy First.", container=TRUE)
+    gmessage(gettext("Add Code Categroy First.", domain = "R-RQDA"), container=TRUE)
   }
   else {
     Encoding(CodeCat$name) <- "UTF-8"
@@ -785,7 +805,7 @@ AddToCodeCategory <- function (Widget = .rqda$.codes_rqda, updateWidget = TRUE)
             UpdateCodeofCatWidget()
           }
           if (!success)
-            gmessage(sprintf("Fail to write to code category of %s",
+            gmessage(sprintf(gettext("Fail to write to code category of %s", domain = "R-RQDA"),
                              Selected))
         }
       }
@@ -800,7 +820,7 @@ AddToCodeCategory <- function (Widget = .rqda$.codes_rqda, updateWidget = TRUE)
 ## ## get the widget for file display. If it does not exist, then return NULL.
 ## sel_index <- tryCatch(sindex(W,includeAnchor=FALSE),error=function(e) {})
 ## ## if the not file is open, it doesn't work.
-## if (is.null(sel_index)) {gmessage("Open a file first!",container=TRUE)}
+## if (is.null(sel_index)) {gmessage(gettext("Open a file first!", domain = "R-RQDA"),container=TRUE)}
 ## else {
 ## CodeTable <-  dbGetQuery(con,"select id,name from freecode where status==1")
 ## SelectedFile <- svalue(.rqda$.root_edit); Encoding(SelectedFile) <- "UTF-8" ##file title

--- a/R/Coding_Buttons.R
+++ b/R/Coding_Buttons.R
@@ -1,8 +1,8 @@
-AddCodeButton <- function(label="Add"){
+AddCodeButton <- function(label=gettext("Add", domain = "R-RQDA")){
   AddCodB <- gbutton(label,
           handler=function(h,...) {
             if (is_projOpen(envir=.rqda,conName="qdacon")) {
-              codename <- ginput("Enter new code. ", icon="info")
+              codename <- ginput(gettext("Enter new code. ", domain = "R-RQDA"), icon="info")
               if (!is.na(codename)){
                 codename <- enc(codename,encoding="UTF-8")
                 addcode(codename)
@@ -17,14 +17,14 @@ AddCodeButton <- function(label="Add"){
 }
 
 
-DeleteCodeButton <- function(label="Delete"){
+DeleteCodeButton <- function(label=gettext("Delete", domain = "R-RQDA")){
   DelCodB <- gbutton(label,
           handler=function(h,...)
           {
             if (is_projOpen(envir=.rqda,conName="qdacon") &
                 length(svalue(.rqda$.codes_rqda))!=0) {
               ## if project is open and one code is selected,then continue
-              del <- gconfirm("Really delete the code?",icon="question")
+              del <- gconfirm(gettext("Really delete the code?", domain = "R-RQDA"),icon="question")
               if (isTRUE(del)){
                 SelectedCode <- svalue(.rqda$.codes_rqda)
                 SelectedCode2 <- enc(SelectedCode,encoding="UTF-8")
@@ -51,17 +51,17 @@ RetrievalButton <- function(label){
               Fid <- GetFileId(condition=.rqda$TOR,type="coded")
               if (length(Fid)>0) {
                 retrieval(Fid=Fid,CodeNameWidget=.rqda$.codes_rqda)
-              } else {gmessage("No codngs associated with this code.",cont=TRUE)}
+              } else {gmessage(gettext("No codings associated with this code.", domain = "R-RQDA"),cont=TRUE)}
               }
               }
                  )
-  gtkWidgetSetTooltipText(getToolkitWidget(RetB),"Retrieve codings of the selected code.")
+  gtkWidgetSetTooltipText(getToolkitWidget(RetB),gettext("Retrieve codings of the selected code.", domain = "R-RQDA"))
   assign("RetB",RetB,envir=button)
   enabled(RetB) <- FALSE
   return(RetB)
 }
 
-Mark_Button<-function(label="Mark",codeListWidget=".codes_rqda",name="MarCodB1"){
+Mark_Button<-function(label=gettext("Mark", domain = "R-RQDA"),codeListWidget=".codes_rqda",name="MarCodB1"){
    ans <- gbutton(label, handler=function(h,...) {
                      MarkCodeFun(codeListWidget=codeListWidget,codingTable=.rqda$codingTable)
                           })
@@ -75,7 +75,7 @@ MarkCodeFun <- function(codeListWidget=".codes_rqda",codingTable="coding"){
     ## insert lable as mark when data is written to database.
   if (is_projOpen(envir=.rqda,conName="qdacon")) {
     currentFile <- tryCatch(svalue(.rqda$.root_edit),error=function(e){NULL})
-      if (is.null(currentFile)) gmessage("Open a file first.",con=TRUE) else{
+      if (is.null(currentFile)) gmessage(gettext("Open a file first.", domain = "R-RQDA"),con=TRUE) else{
         W <- .rqda$.openfile_gui
         con <- .rqda$qdacon
         codeListWidget <- get(codeListWidget,envir=.rqda)
@@ -101,7 +101,7 @@ MarkCodeFun <- function(codeListWidget=".codes_rqda",codingTable="coding"){
             #  print(sprintf("Start: %s  End: %s", ans$start,ans$end))
             #  print(sprintf("Source <%s>", sourcetext))
             #  print(sprintf("Selection <%s>", ans$text))
-            #  gmessage("CONSISTENCY ERROR 1 - See console for details")
+            #  gmessage(gettext("CONSISTENCY ERROR 1 - See console for details", domain = "R-RQDA"))
             #}
 
             ## Exist <-  dbGetQuery(con,sprintf("select rowid, selfirst, selend from coding where cid=%i and fid=%i and status=1",currentCid,currentFid))
@@ -114,7 +114,7 @@ MarkCodeFun <- function(codeListWidget=".codes_rqda",codingTable="coding"){
               success <- is.null(try(RQDAQuery(sprintf("insert into %s (cid,fid, seltext, selfirst, selend, status, owner, date) values (%s, %s, '%s', %s, %s, %s, '%s', '%s') ",
                                                codingTable,DAT$cid, DAT$fid,DAT$seltext, DAT$selfirst, DAT$selend, 1, .rqda$owner, as.character(date()))),silent=TRUE))
               if (success){
-                markRange(widget=.rqda$.openfile_gui,from=ans$start,to=ans$end,rowid=rowid,addButton=TRUE,buttonLabel=SelectedCode,buttonCol=codeCol,codingTable=codingTable)} else{gmessage("Fail to write to database.")}
+                markRange(widget=.rqda$.openfile_gui,from=ans$start,to=ans$end,rowid=rowid,addButton=TRUE,buttonLabel=SelectedCode,buttonCol=codeCol,codingTable=codingTable)} else{gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))}
             } else {
               Exist <- Exist1[,c("selfirst","selend","rowid")]
               Relations <- apply(Exist,1,FUN=function(x) relation(x[c("selfirst","selend")],c(ans$start,ans$end)))
@@ -132,7 +132,7 @@ MarkCodeFun <- function(codeListWidget=".codes_rqda",codingTable="coding"){
 		    if (success){
 			markRange(widget=.rqda$.openfile_gui,from=ans$start,to=ans$end,rowid=rowid,addButton=TRUE,
 				  buttonLabel=SelectedCode,buttonCol=codeCol,codingTable=codingTable)
-		    } else {gmessage("fail to write to data base.",con=TRUE)}
+		    } else {gmessage(gettext("Fail to write to data base.", domain = "R-RQDA"),con=TRUE)}
                     ## if there are no overlap in any kind, just write to database; otherwise, pass to else{}.
                 } else {
                   del1 <-(Exist$Relation =="inclusion" & (is.na(Exist$WhichMin) | Exist$WhichMin==2))
@@ -167,7 +167,7 @@ MarkCodeFun <- function(codeListWidget=".codes_rqda",codingTable="coding"){
                     #  print(sprintf("Start: %s  End: %s", Sel[1],Sel[2]))
                     #  print(sprintf("Source <%s>", sourcetext))
                     #  print(sprintf("Selection <%s>", seltext))
-                    #  gmessage("CONSISTENCY ERROR 2 - See console for details")
+                    #  gmessage(gettext("CONSISTENCY ERROR 2 - See console for details", domain = "R-RQDA"))
                     #}
                     
                     DAT$seltext <- enc(DAT$seltext)
@@ -176,13 +176,13 @@ MarkCodeFun <- function(codeListWidget=".codes_rqda",codingTable="coding"){
                     success <- is.null(try(RQDAQuery(sprintf("insert into %s (cid,fid, seltext, selfirst, selend, status, owner, date, memo) values (%s, %s, '%s', %s, %s, %s, '%s', '%s','%s') ",
                                                    codingTable,DAT$cid, DAT$fid,DAT$seltext, DAT$selfirst, DAT$selend, 1, .rqda$owner, as.character(date()), DAT$memo)),silent=TRUE))
                     if (success){
-                        markRange(widget=.rqda$.openfile_gui,from=Sel[1],to=Sel[2],rowid=rowid,addButton=TRUE,buttonLabel=SelectedCode,buttonCol=codeCol,codingTable=codingTable)}else{gmessage("Fail to write to database.")}
+                        markRange(widget=.rqda$.openfile_gui,from=Sel[1],to=Sel[2],rowid=rowid,addButton=TRUE,buttonLabel=SelectedCode,buttonCol=codeCol,codingTable=codingTable)}else{gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))}
                 }
               }}}}}}}}
 
 
-Unmark_Button <- function(label="Unmark",codeListWidget=.rqda$.codes_rqda,name="UnMarB1"){
-  ans <- gbutton("Unmark", handler=function(h,...) {
+Unmark_Button <- function(label=gettext("Unmark", domain = "R-RQDA"),codeListWidget=.rqda$.codes_rqda,name="UnMarB1"){
+  ans <- gbutton(gettext("Unmark", domain = "R-RQDA"), handler=function(h,...) {
     UnMarkCodeFunByRowid(codeListWidget=codeListWidget,codingTable=.rqda$codingTable)
     enabled(button$UnMarB1) <- FALSE
   }
@@ -205,7 +205,7 @@ UnMarkCodeFun <- function(codeListWidget=.rqda$.codes_rqda,codingTable="coding")
       ## codeListWidget <- get(codeListWidget,envir=.rqda)
       SelectedCode <- svalue(codeListWidget)
       if (length(SelectedCode)==0) {
-        gmessage("Select a code first.",con=TRUE)
+        gmessage(gettext("Select a code first.", domain = "R-RQDA"),con=TRUE)
       } else {
         Encoding(SelectedCode) <- "UTF-8"
         SelectedCode2 <- enc(SelectedCode,"UTF-8")
@@ -221,7 +221,7 @@ UnMarkCodeFun <- function(codeListWidget=.rqda$.codes_rqda,codingTable="coding")
         rowid <- codings_index$rowid[(codings_index$selfirst  >= idx1$startN) &
                                      (codings_index$selend  <= idx1$endN)]
         if (length(rowid)==0) {
-          gmessage("Select a code and one of its codings exactly first.",con=TRUE)
+          gmessage(gettext("Select a code and one of its codings exactly first.", domain = "R-RQDA"),con=TRUE)
         } else {
           for (j in rowid) {
           ClearMark(W,min=idx2$startN,max=idx2$endN)
@@ -278,22 +278,22 @@ UnMarkCodeFunByRowid <- function(codeListWidget=.rqda$.codes_rqda,codingTable="c
     }
 }
 
-CodeMemoButton <- function(label="C-Memo",...){
+CodeMemoButton <- function(label=gettext("C-Memo", domain = "R-RQDA"),...){
   codememobuton <- gbutton(label, handler=function(h,...){
-    MemoWidget("code",.rqda$.codes_rqda,"freecode")
+    MemoWidget(gettext("code", domain = "R-RQDA"),.rqda$.codes_rqda,"freecode")
   }
           )
-  gtkWidgetSetTooltipText(getToolkitWidget(codememobuton),"Memo for selected code.")
+  gtkWidgetSetTooltipText(getToolkitWidget(codememobuton),gettext("Memo for selected code.", domain = "R-RQDA"))
   assign("codememobuton",codememobuton,envir=button)
   enabled(codememobuton) <- FALSE
   return(codememobuton)
 }
 
 
-CodingMemoButton <- function(label="C2Memo")
+CodingMemoButton <- function(label=gettext("C2Memo", domain = "R-RQDA"))
 {
 
-  InsertCodingMemoAnchor <- function (index,rowid,label="[Coding Memo]",title)
+  InsertCodingMemoAnchor <- function (index,rowid,label=gettext("[Coding Memo]", domain = "R-RQDA"),title)
     {
       ## don't use this function.
       ## use Annotation to add anno to a file.
@@ -325,7 +325,7 @@ CodingMemoButton <- function(label="C2Memo")
     assign(".codingmemo",.codingmemo, envir=.rqda)
     .codingmemo <- get(".codingmemo",envir=.rqda)
     .codingmemo2 <- gpanedgroup(horizontal = FALSE, container=.codingmemo)
-    gbutton("Save Coding Memo",container=.codingmemo2,handler=function(h,...){
+    gbutton(gettext("Save Coding Memo", domain = "R-RQDA"),container=.codingmemo2,handler=function(h,...){
       newcontent <- svalue(.rqda$.cdmemocontent)
       newcontent <- enc(newcontent,encoding="UTF-8") ## take care of double quote.
       RQDAQuery(sprintf("update coding set memo='%s' where rowid=%i",newcontent,rowid))
@@ -351,10 +351,10 @@ CodingMemoButton <- function(label="C2Memo")
       sel_index <- tryCatch(sindex(W,includeAnchor=FALSE),error=function(e) {})
       AnchorPos <- tryCatch(sindex(W,includeAnchor=TRUE)$startN,error=function(e) {})
       ## if the not file is open, it doesn't work.
-      if (is.null(sel_index)) {gmessage("Open a file first!",container=TRUE)}
+      if (is.null(sel_index)) {gmessage(gettext("Open a file first!", domain = "R-RQDA"),container=TRUE)}
       else {
         SelectedCode <- svalue(.rqda$.codes_rqda)
-        if (length(SelectedCode)==0) gmessage("select a code first.",container=TRUE) else {
+        if (length(SelectedCode)==0) gmessage(gettext("select a code first.", domain = "R-RQDA"),container=TRUE) else {
           Encoding(SelectedCode) <- "UTF-8"
           SelectedCode2 <- enc(SelectedCode,"UTF-8")
           currentCid <-  RQDAQuery(sprintf("select id from freecode where name='%s'",SelectedCode2))[,1]
@@ -369,13 +369,13 @@ CodingMemoButton <- function(label="C2Memo")
                                        (codings_index$selend  <= sel_index$endN)&
                                        (codings_index$selend  >= sel_index$endN - 2)
                                        ] ## determine which one is the current text chunk?
-          if (length(rowid)!= 1) {gmessage("Select the exact CODING AND the corresponding CODE first.", container=TRUE)}
+          if (length(rowid)!= 1) {gmessage(gettext("Select the exact CODING AND the corresponding CODE first.", domain = "R-RQDA"), container=TRUE)}
           else {
             OpenCodingMemo(rowid=rowid,AnchorPos=AnchorPos,title=sprintf("Coding Memo: %s",SelectedCode))
           }
         }
       }}})
-  gtkWidgetSetTooltipText(getToolkitWidget(c2memobutton),"Memo for a Coding.")
+  gtkWidgetSetTooltipText(getToolkitWidget(c2memobutton),gettext("Memo for a Coding.", domain = "R-RQDA"))
   assign("c2memobutton",c2memobutton,envir=button)
   enabled(c2memobutton) <- FALSE
   return(c2memobutton)
@@ -383,7 +383,7 @@ CodingMemoButton <- function(label="C2Memo")
 
 
 
-FreeCode_RenameButton <- function(label="Rename",CodeNamesWidget=.rqda$.codes_rqda,...)
+FreeCode_RenameButton <- function(label=gettext("Rename", domain = "R-RQDA"),CodeNamesWidget=.rqda$.codes_rqda,...)
 {
     ## rename of selected file.
     FreCodRenB <- gbutton(label,handler=function(h,...) {
@@ -391,11 +391,11 @@ FreeCode_RenameButton <- function(label="Rename",CodeNamesWidget=.rqda$.codes_rq
             ## if project is open, then continue
             selectedCodeName <- svalue(CodeNamesWidget)
             if (length(selectedCodeName)==0){
-                gmessage("Select a code first.",icon="error",container=TRUE)
+                gmessage(gettext("Select a code first.", domain = "R-RQDA"),icon="error",container=TRUE)
             }
             else {
                 ## get the new file names
-                NewCodeName <- ginput("Enter new code name. ", text=selectedCodeName, icon="info")
+                NewCodeName <- ginput(gettext("Enter new code name. ", domain = "R-RQDA"), text=selectedCodeName, icon="info")
                 if (!is.na(NewCodeName)) {
                     Encoding(NewCodeName) <- Encoding(selectedCodeName) <- "UTF-8"
                     ## update the name in source table by a function
@@ -414,12 +414,12 @@ FreeCode_RenameButton <- function(label="Rename",CodeNamesWidget=.rqda$.codes_rq
 }
 
 
-AnnotationButton <- function(label="Add Anno"){
+AnnotationButton <- function(label=gettext("Add Anno", domain = "R-RQDA")){
   AnnB <- gbutton(label,handler=function(h,...) {
     if (is_projOpen(envir=.rqda,conName="qdacon")) {
       Annotation()
     }})
-  gtkWidgetSetTooltipText(getToolkitWidget(AnnB),"Add new annotation to the open file\nat position of cursor.")
+  gtkWidgetSetTooltipText(getToolkitWidget(AnnB),gettext("Add new annotation to the open file\nat position of cursor.", domain = "R-RQDA"))
   assign("AnnB",AnnB,envir=button)
   enabled(AnnB) <- FALSE
   return(AnnB)
@@ -427,154 +427,158 @@ AnnotationButton <- function(label="Add Anno"){
 
 
 ## popup-menu
-CodesNamesWidgetMenu <- list()
-CodesNamesWidgetMenu$"Add To Code Category..."$handler <- function(h, ...) {
+GetCodesNamesWidgetMenu <- function()
+{
+  CodesNamesWidgetMenu <- list()
+  CodesNamesWidgetMenu[[gettext("Add To Code Category...", domain = "R-RQDA")]]$handler <- function(h, ...) {
     AddToCodeCategory()
-}
-CodesNamesWidgetMenu$"All Code Memos"$handler <- function(h, ...) {
+  }
+  CodesNamesWidgetMenu[[gettext("All Code Memos", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    print(getMemos())
+      print(getMemos())
     }
   }
-CodesNamesWidgetMenu$"All Annotations"$handler <- function(h, ...) {
+  CodesNamesWidgetMenu[[gettext("All Annotations", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    print(getAnnos())
+      print(getAnnos())
     }
   }
-CodesNamesWidgetMenu$"Code Memo"$handler <- function(h, ...) {
+  CodesNamesWidgetMenu[[gettext("Code Memo", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    MemoWidget("code",.rqda$.codes_rqda,"freecode")
+      MemoWidget(gettext("code", domain = "R-RQDA"),.rqda$.codes_rqda,"freecode")
     }
   }
-CodesNamesWidgetMenu$"Codings of Multiple Codes"$handler <- function(h, ...) {
+  CodesNamesWidgetMenu[[gettext("Codings of Multiple Codes", domain = "R-RQDA")]]$handler <- function(h, ...) {
     ct <- getCodingsOfCodes(fid=getFileIds(condition=.rqda$TOR))
     print.codingsByOne(ct)
   }
-CodesNamesWidgetMenu$"Export Codings as HTML"$handler <- function(h, ...) {
+  CodesNamesWidgetMenu[[gettext("Export Codings as HTML", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    path=gfile(type="save",text = "Type a name for the exported codings and click OK.")
-    if (!is.na(path)){
-      Encoding(path) <- "UTF-8"
-      path <- sprintf("%s.html",path)
-      if (.rqda$TOR == "uncondition") fid <- NULL else fid <- getFileIds(condition=.rqda$TOR)
-      ExportCoding(file=path,Fid=fid)
-    }}}
-CodesNamesWidgetMenu$"Highlight All Codings"$handler <- function(h, ...) {HL_AllCodings()}
-CodesNamesWidgetMenu$"Highlight Codings with Memo"$handler <- function(h, ...) {HL_CodingWithMemo()}
-CodesNamesWidgetMenu$"Merge Selected with..."$handler <- function(h, ...) {
+      path=gfile(type="save",text = gettext("Type a name for the exported codings and click OK.", domain = "R-RQDA"))
+      if (!is.na(path)){
+        Encoding(path) <- "UTF-8"
+        path <- sprintf("%s.html",path)
+        if (.rqda$TOR == "uncondition") fid <- NULL else fid <- getFileIds(condition=.rqda$TOR)
+        ExportCoding(file=path,Fid=fid)
+  }}}
+  CodesNamesWidgetMenu[[gettext("Highlight All Codings", domain = "R-RQDA")]]$handler <- function(h, ...) {HL_AllCodings()}
+  CodesNamesWidgetMenu[[gettext("Highlight Codings with Memo", domain = "R-RQDA")]]$handler <- function(h, ...) {HL_CodingWithMemo()}
+  CodesNamesWidgetMenu[[gettext("Merge Selected with...", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-        Selected1 <- svalue(.rqda$.codes_rqda)
-        cid1 <- dbGetQuery(.rqda$qdacon,sprintf("select id from freecode where name='%s'",Selected1))[1,1]
-        Selected2 <- gselect.list(as.character(.rqda$.codes_rqda[]), x=getOption("widgetCoordinate")[1])
-        if (Selected2!="" && Selected1!=Selected2) cid2 <- dbGetQuery(.rqda$qdacon,sprintf("select id from freecode where name='%s'",Selected2))[1,1]
-        mergeCodes(cid1,cid2)
-        CodeNamesWidgetUpdate()
+      Selected1 <- svalue(.rqda$.codes_rqda)
+      cid1 <- dbGetQuery(.rqda$qdacon,sprintf("select id from freecode where name='%s'",Selected1))[1,1]
+      Selected2 <- gselect.list(as.character(.rqda$.codes_rqda[]), x=getOption("widgetCoordinate")[1])
+      if (Selected2!="" && Selected1!=Selected2) cid2 <- dbGetQuery(.rqda$qdacon,sprintf("select id from freecode where name='%s'",Selected2))[1,1]
+      mergeCodes(cid1,cid2)
+      CodeNamesWidgetUpdate()
     }
-}
+  }
 
-CodesNamesWidgetMenu$"Show Codes With Codings"$handler <- function(h, ...) {
+  CodesNamesWidgetMenu[[gettext("Show Codes With Codings", domain = "R-RQDA")]]$handler <- function(h, ...) {
     CodeWithCoding(.rqda$TOR)
-}
-CodesNamesWidgetMenu$"Show Codes Without Codings"$handler <- function(h, ...) {
+  }
+  CodesNamesWidgetMenu[[gettext("Show Codes Without Codings", domain = "R-RQDA")]]$handler <- function(h, ...) {
     CodeWithoutCoding(condition=.rqda$TOR)
-}
-CodesNamesWidgetMenu$"Show Codes With Code Category"$handler <- function(h, ...) {
-    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-        cid <- RQDAQuery("select id from freecode where status=1 and id in (select cid from treecode where status=1)")
-        if (nrow(cid)!=0) {
-            cid <- cid[[1]]
-            CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
-        } else gmessage("All codes are assiged to code category.",container=TRUE)
-    }
-}
-CodesNamesWidgetMenu$"Show Codes Without Code Category"$handler <- function(h, ...) {
-    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-        cid <- RQDAQuery("select id from freecode where status=1 and id not in (select cid from treecode where status=1)")
-        if (nrow(cid)!=0) {
-            cid <- cid[[1]]
-            CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
-        } else gmessage("All codes are assiged to code category.",container=TRUE)
-    }
-}
-CodesNamesWidgetMenu$"Show Codes With Memo"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    cid <- dbGetQuery(.rqda$qdacon,"select id from freecode where memo is not null and memo != ''")
-    if (nrow(cid)!=0) {
-    cid <- cid[[1]]
-    CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
-  } else gmessage("No Code with memo.",container=TRUE)
   }
-}
-CodesNamesWidgetMenu$"Show Codes Without Memo"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    cid <- dbGetQuery(.rqda$qdacon,"select id from freecode where memo is null or memo = ''")
-    if (nrow(cid)!=0) {
-      cid <- cid[[1]]
-      CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
-    } else gmessage("No Code with memo.",container=TRUE)
+  CodesNamesWidgetMenu[[gettext("Show Codes With Code Category", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      cid <- RQDAQuery("select id from freecode where status=1 and id in (select cid from treecode where status=1)")
+      if (nrow(cid)!=0) {
+        cid <- cid[[1]]
+        CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
+      } else gmessage(gettext("All codes are assiged to code category.", domain = "R-RQDA"),container=TRUE)
+    }
   }
-}
+  CodesNamesWidgetMenu[[gettext("Show Codes Without Code Category", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      cid <- RQDAQuery("select id from freecode where status=1 and id not in (select cid from treecode where status=1)")
+      if (nrow(cid)!=0) {
+        cid <- cid[[1]]
+        CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
+      } else gmessage(gettext("All codes are assiged to code category.", domain = "R-RQDA"),container=TRUE)
+    }
+  }
+  CodesNamesWidgetMenu[[gettext("Show Codes With Memo", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      cid <- dbGetQuery(.rqda$qdacon,"select id from freecode where memo is not null and memo != ''")
+      if (nrow(cid)!=0) {
+        cid <- cid[[1]]
+        CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
+      } else gmessage(gettext("No Code with memo.", domain = "R-RQDA"),container=TRUE)
+    }
+  }
+  CodesNamesWidgetMenu[[gettext("Show Codes Without Memo", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      cid <- dbGetQuery(.rqda$qdacon,"select id from freecode where memo is null or memo = ''")
+      if (nrow(cid)!=0) {
+        cid <- cid[[1]]
+        CodeNamesWidgetUpdate(CodeNamesWidget=.rqda$.codes_rqda,CodeId=cid,sortByTime=FALSE)
+      } else gmessage(gettext("No Code with memo.", domain = "R-RQDA"),container=TRUE)
+    }
+  }
 
-CodesNamesWidgetMenu$"Show Codes With Selected File"$handler <- function(h, ...) {
+  CodesNamesWidgetMenu[[gettext("Show Codes With Selected File", domain = "R-RQDA")]]$handler <- function(h, ...) {
     fname <- svalue(.rqda$.fnames_rqda)
     if (length(fname) > 0) {
-        fname <- enc(fname)
-        codes <- RQDAQuery(sprintf("select freecode.name from freecode where freecode.status=1 and freecode.id in (
-         select coding.cid from coding where coding.status=1 and coding.fid in (
-               select source.id from source where source.status=1 and source.name='%s'
-               )
-        )", fname))
-        if (nrow(codes) > 0){
-            Encoding(codes$name) <- "UTF-8"
-            .rqda$.codes_rqda[] <- codes$name
-        }
+      fname <- enc(fname)
+      codes <- RQDAQuery(sprintf("select freecode.name from freecode where freecode.status=1 and freecode.id in (
+                                 select coding.cid from coding where coding.status=1 and coding.fid in (
+                                                                                                        select source.id from source where source.status=1 and source.name='%s'
+                                                                                                        )
+                                 )", fname))
+      if (nrow(codes) > 0){
+        Encoding(codes$name) <- "UTF-8"
+        .rqda$.codes_rqda[] <- codes$name
+      }
     }
-}
+  }
 
-CodesNamesWidgetMenu$"Set Coding Mark Color"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    Selected <- svalue(.rqda$.codes_rqda)
-    Selected <- enc(Selected,"UTF-8")
-    codeInfo <- dbGetQuery(.rqda$qdacon,sprintf("select id,color from freecode where name='%s'",Selected))[1,]
-    cid <- codeInfo[,1]
-    codeColor <- codeInfo[,2]
-    if (is.na(codeColor)) title <- "Change color to..." else title <- sprintf("Change from '%s' to...",codeColor)
-    newCol <- gselect.list(colors(), multiple = FALSE, title = title,, x=getOption("widgetCoordinate")[1])
-    if (newCol!="" && length(newCol)!=0){
-    if (!identical(codeColor,newCol)){
-      RQDAQuery(sprintf("update freecode set color='%s' where id =%i",newCol,cid))
-    }
-  }}
-}
-
-CodesNamesWidgetMenu$"Sort: By Created Time"$handler <- function(h, ...) {
+  CodesNamesWidgetMenu[[gettext("Set Coding Mark Color", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-        CodeNamesUpdate(sortByTime=TRUE)
+      Selected <- svalue(.rqda$.codes_rqda)
+      Selected <- enc(Selected,"UTF-8")
+      codeInfo <- dbGetQuery(.rqda$qdacon,sprintf("select id,color from freecode where name='%s'",Selected))[1,]
+      cid <- codeInfo[,1]
+      codeColor <- codeInfo[,2]
+      if (is.na(codeColor)) title <- "Change color to..." else title <- sprintf("Change from '%s' to...",codeColor)
+      newCol <- gselect.list(colors(), multiple = FALSE, title = title,, x=getOption("widgetCoordinate")[1])
+      if (newCol!="" && length(newCol)!=0){
+        if (!identical(codeColor,newCol)){
+          RQDAQuery(sprintf("update freecode set color='%s' where id =%i",newCol,cid))
+        }
+    }}
+  }
+
+  CodesNamesWidgetMenu[[gettext("Sort: By Created Time", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      CodeNamesUpdate(sortByTime=TRUE)
     }
-}
-CodesNamesWidgetMenu$"Sort: Most to Least Frequently Used"$handler <- function(h, ...) {
+  }
+  CodesNamesWidgetMenu[[gettext("Sort: Most to Least Frequently Used", domain = "R-RQDA")]]$handler <- function(h, ...) {
     freq <- RQDAQuery("select count(cid) as freq, freecode.name, freecode.status from freecode left join coding on cid=freecode.id group by freecode.name order by freq desc")
     if (nrow(freq)>0){
-        Encoding(freq$name) <- "UTF-8"
-        freq <- subset(freq, status==1)
-        CodeNamesWidget=.rqda$.codes_rqda
-        CodeNamesWidget[] <- freq$name
+      Encoding(freq$name) <- "UTF-8"
+      freq <- subset(freq, status==1)
+      CodeNamesWidget=.rqda$.codes_rqda
+      CodeNamesWidget[] <- freq$name
     }
-}
-CodesNamesWidgetMenu$"Sort: Least to Most Frequently Used"$handler <- function(h, ...) {
+  }
+  CodesNamesWidgetMenu[[gettext("Sort: Least to Most Frequently Used", domain = "R-RQDA")]]$handler <- function(h, ...) {
     freq <- RQDAQuery("select count(cid) as freq, freecode.name, freecode.status from freecode left join coding on cid=freecode.id group by freecode.name order by freq asc")
     if (nrow(freq)>0){
-        Encoding(freq$name) <- "UTF-8"
-        freq <- subset(freq, status==1)
-        CodeNamesWidget=.rqda$.codes_rqda
-        CodeNamesWidget[] <- freq$name
+      Encoding(freq$name) <- "UTF-8"
+      freq <- subset(freq, status==1)
+      CodeNamesWidget=.rqda$.codes_rqda
+      CodeNamesWidget[] <- freq$name
     }
+  }
+  CodesNamesWidgetMenu
 }
 
 
 ######################################## un-used functions
 ## HL_ALLButton <- function(){
-##     ans <- gbutton("HL ALL",
+##     ans <- gbutton(gettext("HL ALL", domain = "R-RQDA"),
 ##           handler=function(h,...) {
 ##             if (is_projOpen(envir=.rqda,conName="qdacon")) {
 ##               con <- .rqda$qdacon
@@ -620,7 +624,7 @@ CodesNamesWidgetMenu$"Sort: Least to Most Frequently Used"$handler <- function(h
 ##   if (is_projOpen(envir=.rqda,conName="qdacon")) {
 ##       con <- .rqda$qdacon
 ##       currentFile <- tryCatch(svalue(.rqda$.root_edit),error=function(e){NULL})
-##       if (is.null(currentFile)) gmessage("Open a file first.",container=TRUE) else{
+##       if (is.null(currentFile)) gmessage(gettext("Open a file first.", domain = "R-RQDA"),container=TRUE) else{
 ##         W <- .rqda$.openfile_gui
 ##         codeListWidget <- get(codeListWidget,envir=.rqda)
 ##         ans <- mark(W,addButton=TRUE,buttonLabel=svalue(codeListWidget))
@@ -638,7 +642,7 @@ CodesNamesWidgetMenu$"Sort: Least to Most Frequently Used"$handler <- function(h
 ##                             owner=.rqda$owner,date=date(),memo=NA)
 ##           if (nrow(Exist)==0){
 ##             success <- dbWriteTable(.rqda$qdacon,"coding",DAT,row.name=FALSE,append=TRUE)
-##             if (!success) gmessage("Fail to write to database.")
+##             if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
 ##         } else {
 ##           Relations <- apply(Exist,1,FUN=function(x) relation(x[c("selfirst","selend")],c(ans$start,ans$end)))
 ##           Exist$Relation <- sapply(Relations,FUN=function(x)x$Relation)
@@ -649,7 +653,7 @@ CodesNamesWidgetMenu$"Sort: Least to Most Frequently Used"$handler <- function(h
 ##             Exist$End <- sapply(Relations,FUN=function(x)x$UnionIndex[2])
 ##             if (all(Exist$Relation=="proximity")){
 ##               success <- dbWriteTable(.rqda$qdacon,"coding",DAT,row.name=FALSE,append=TRUE)
-##               if (!success) gmessage("Fail to write to database.")
+##               if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
 ##               ## if there are no overlap in any kind, just write to database; otherwise, pass to else{}.
 ##             } else {
 ##               del1 <- (Exist$Relation =="inclusion" & any(Exist$WhichMin==2,Exist$WhichMax==2))
@@ -671,7 +675,7 @@ CodesNamesWidgetMenu$"Sort: Least to Most Frequently Used"$handler <- function(h
 ##                                   selfirst=Sel[1],selend=Sel[2],status=1,
 ##                                   owner=.rqda$owner,date=date(),memo=memo)
 ##                 success <- dbWriteTable(.rqda$qdacon,"coding",DAT,row.name=FALSE,append=TRUE)
-##                 if (!success) gmessage("Fail to write to database.")
+##                 if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
 ##               }
 ##             }
 ##           }

--- a/R/FileButton.R
+++ b/R/FileButton.R
@@ -1,4 +1,4 @@
-ImportFileButton <- function(label="Import", container,...)
+ImportFileButton <- function(label=gettext("Import", domain = "R-RQDA"), container,...)
 {
   ImpFilB <- gbutton(label, container=container, handler=function(h,...){
       path <- gfile(type="open",filter=list("text files" = list(mime.types = c("text/plain")),
@@ -14,7 +14,7 @@ ImportFileButton <- function(label="Import", container,...)
   gtkWidgetSetSensitive(button$ImpFilB@widget@widget,FALSE)
 }
 
-NewFileButton <- function(label="New", container,...)
+NewFileButton <- function(label=gettext("New", domain = "R-RQDA"), container,...)
 {
     NewFilB <- gbutton(label, container=container, handler=function(h,...){
         if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
@@ -26,15 +26,14 @@ NewFileButton <- function(label="New", container,...)
     enabled(NewFilB) <- FALSE
 }
 
-DeleteFileButton <- function(label="Delete", container,...){
+DeleteFileButton <- function(label=gettext("Delete", domain = "R-RQDA"), container,...){
   DelFilB <- gbutton(label,container=container,handler=function(h,...){
               SelectedFile <- svalue(.rqda$.fnames_rqda)
               Encoding(SelectedFile) <- "UTF-8"
               ## if the project open and a file is selected, then continue the action
               del <- gconfirm(ngettext(length(SelectedFile),
                                        "Really delete the file?",
-                                       "Really delete the files?")
-                                       ,icon="question")
+                                       "Really delete the files?", domain = "R-RQDA"), icon="question")
               if (isTRUE(del)) {
                 ## con <- .rqda$qdacon
                   for (i in SelectedFile){
@@ -57,7 +56,7 @@ DeleteFileButton <- function(label="Delete", container,...){
   gtkWidgetSetSensitive(button$DelFilB@widget@widget,FALSE)
 }
 
-ViewFileButton <-  function(label="Open", container,...)
+ViewFileButton <-  function(label=gettext("Open", domain = "R-RQDA"), container,...)
 {
   VieFilB <- gbutton(label,container=container,handler=function(h,...)
           {
@@ -69,27 +68,27 @@ ViewFileButton <-  function(label="Open", container,...)
 }
 
 
-File_MemoButton <- function(label="Memo", container=.rqda$.files_button,FileWidget=.rqda$.fnames_rqda,...){
+File_MemoButton <- function(label=gettext("Memo", domain = "R-RQDA"), container=.rqda$.files_button,FileWidget=.rqda$.fnames_rqda,...){
   ## memo of selected file.
   FilMemB <- gbutton(label, container=container, handler=function(h,...) {
-      MemoWidget("File",FileWidget,"source")
+      MemoWidget(gettext("File", domain = "R-RQDA"),FileWidget,"source")
   }
           )
   assign("FilMemB",FilMemB,envir=button)
   gtkWidgetSetSensitive(button$FilMemB@widget@widget,FALSE)
 }
 
-File_RenameButton <- function(label="Rename", container=.rqda$.files_button,FileWidget=.rqda$.fnames_rqda,...)
+File_RenameButton <- function(label=gettext("Rename", domain = "R-RQDA"), container=.rqda$.files_button,FileWidget=.rqda$.fnames_rqda,...)
 {
   ## rename of selected file.
   FilRenB <- gbutton(label, container=container, handler=function(h,...) {
       selectedFN <- svalue(FileWidget)
       if (length(selectedFN)==0){
-        gmessage("Select a file first.",icon="error",container=TRUE)
+        gmessage(gettext("Select a file first.", domain = "R-RQDA"),icon="error",container=TRUE)
       }
       else {
         ## get the new file names
-        NewFileName <- ginput("Enter new file name. ",text=selectedFN, icon="info")
+        NewFileName <- ginput(gettext("Enter new file name. ", domain = "R-RQDA"),text=selectedFN, icon="info")
         if (!is.na(NewFileName)) {
           Encoding(NewFileName) <- "UTF-8"
           ## otherwise, R transform it into local Encoding rather than keep it as UTF-8
@@ -108,7 +107,7 @@ File_RenameButton <- function(label="Rename", container=.rqda$.files_button,File
   gtkWidgetSetSensitive(button$FilRenB@widget@widget,FALSE)
 }
 
-FileAttribute_Button <- function(label="Attribute",container=.rqda$.files_button,FileWidget=.rqda$.fnames_rqda,...)
+FileAttribute_Button <- function(label=gettext("Attribute", domain = "R-RQDA"),container=.rqda$.files_button,FileWidget=.rqda$.fnames_rqda,...)
 {
     FileAttrB <- gbutton(label, container=container, handler=function(h,...) {
         if (is_projOpen(envir=.rqda,conName="qdacon")) {
@@ -140,7 +139,7 @@ AddNewFileFun <- function(){
     assign(".AddNewFileWidget2",gpanedgroup(horizontal = FALSE, container=get(".AddNewFileWidget",envir=.rqda)),envir=.rqda)
     saveFileFun <- function() {
       ## require a title for the file
-      Ftitle <- ginput("Enter the title", icon="info")
+      Ftitle <- ginput(gettext("Enter the title", domain = "R-RQDA"), icon="info")
       if (!is.na(Ftitle)) {
         Ftitle <- enc(Ftitle,"UTF-8")
         if (nrow(dbGetQuery(.rqda$qdacon,sprintf("select name from source where name='%s'",Ftitle)))!=0) {
@@ -166,10 +165,10 @@ AddNewFileFun <- function(){
   } ## end of saveFileFun
 
     gl <- glayout(homogeneous=T,container=get(".AddNewFileWidget2",envir=.rqda))
-    AddNewFilB <- gbutton("Save To Project", handler=function(h,...){saveFileFun()})
+    AddNewFilB <- gbutton(gettext("Save To Project", domain = "R-RQDA"), handler=function(h,...){saveFileFun()})
     enabled(AddNewFilB) <- FALSE
     assign("AddNewFilB",AddNewFilB,envir=button)
-    AddNewFilB2 <- gbutton("Save and close", handler=function(h,...){
+    AddNewFilB2 <- gbutton(gettext("Save and close", domain = "R-RQDA"), handler=function(h,...){
         suc <- saveFileFun()
         if (suc) dispose(.rqda$.AddNewFileWidget)
     }
@@ -198,187 +197,193 @@ AddNewFileFun <- function(){
 
 
 ## pop-up menu of add to case and F-cat from Files Tab
-FileNamesWidgetMenu <- list()
-FileNamesWidgetMenu$"Add New File ..."$handler <- function(h, ...) {
-  if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-    AddNewFileFun()
+## The translations must be created at run time, otherwise they will not work.
+GetFileNamesWidgetMenu <- function()
+{
+  FileNamesWidgetMenu <- list()
+  FileNamesWidgetMenu[[gettext("Add New File ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
+      AddNewFileFun()
+    }
   }
-}
-FileNamesWidgetMenu$"Add To Case ..."$handler <- function(h, ...) {
+  FileNamesWidgetMenu[[gettext("Add To Case ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
       AddFileToCaselinkage()
       UpdateFileofCaseWidget()
     }
   }
-FileNamesWidgetMenu$"Add To File Category ..."$handler <- function(h, ...) {
+  FileNamesWidgetMenu[[gettext("Add To File Category ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
       AddToFileCategory()
       UpdateFileofCatWidget()
     }
   }
-FileNamesWidgetMenu$"Add/modify Attributes of The Open File..."$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-    Selected <- tryCatch(svalue(.rqda$.root_edit),error=function(e){NULL})
-    if (!is.null(Selected)){
-      fileId <- RQDAQuery(sprintf("select id from source where status=1 and name='%s'",
-                                  enc(Selected)))[,1]
-    FileAttrFun(fileId=fileId,title=Selected)
+  FileNamesWidgetMenu[[gettext("Add/modify Attributes of The Open File...", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      Selected <- tryCatch(svalue(.rqda$.root_edit),error=function(e){NULL})
+      if (!is.null(Selected)){
+        fileId <- RQDAQuery(sprintf("select id from source where status=1 and name='%s'",
+                                    enc(Selected)))[,1]
+        FileAttrFun(fileId=fileId,title=Selected)
+      }
+  }}
+  FileNamesWidgetMenu[[gettext("View Attributes", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      viewFileAttr()
+    }
   }
-}}
-FileNamesWidgetMenu$"View Attributes"$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
-   viewFileAttr()
-  }
-}
 
-FileNamesWidgetMenu$"Codings of selected file(s)"$handler <- function(h,...){
-  if (is_projOpen(envir=.rqda,conName="qdacon")) {
+  FileNamesWidgetMenu[[gettext("Codings of selected file(s)", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
       fid =getFileIds(type="selected")
       if (length(fid)>0) {
-         getCodingsFromFiles(Fid=fid)
-      } else gmessage("No coded file is selected.")
+        getCodingsFromFiles(Fid=fid)
+      } else gmessage(gettext("No coded file is selected.", domain = "R-RQDA"))
+    }
   }
-}
 
-FileNamesWidgetMenu$"Export File Attributes"$handler <- function(h,...){
+  FileNamesWidgetMenu[[gettext("Export File Attributes", domain = "R-RQDA")]]$handler <- function(h,...){
     if (is_projOpen(envir=.rqda,conName="qdacon")) {
-        fName <- gfile(type='save',filter=list("csv"=list(pattern=c("*.csv"))))
-        Encoding(fName) <- "UTF-8"
-        if (length(grep(".csv$",fName))==0) fName <- sprintf("%s.csv",fName)
-        write.csv(GetAttr("file"), row.names=FALSE, file=fName, na="")
+      fName <- gfile(type='save',filter=list("csv"=list(pattern=c("*.csv"))))
+      Encoding(fName) <- "UTF-8"
+      if (length(grep(".csv$",fName))==0) fName <- sprintf("%s.csv",fName)
+      write.csv(GetAttr("file"), row.names=FALSE, file=fName, na="")
     }
-}
-FileNamesWidgetMenu$"Edit Seleted File"$handler <- function(h, ...) {
-  EditFileFun()
-}
-FileNamesWidgetMenu$"Export Coded file as HTML"$handler <- function(h, ...) {
+  }
+  FileNamesWidgetMenu[[gettext("Edit Seleted File", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    EditFileFun()
+  }
+  FileNamesWidgetMenu[[gettext("Export Coded file as HTML", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-        path=gfile(type="save",text = "Type a name for the exported codings and click OK.")
-        if (!is.na(path)){
-            Encoding(path) <- "UTF-8"
-            path <- sprintf("%s.html",path)
-            exportCodedFile(file=path,getFileIds(type="selected")[1])
-        }}}
+      path=gfile(type="save",text = gettext("Type a name for the exported codings and click OK.", domain = "R-RQDA"))
+      if (!is.na(path)){
+        Encoding(path) <- "UTF-8"
+        path <- sprintf("%s.html",path)
+        exportCodedFile(file=path,getFileIds(type="selected")[1])
+  }}}
 
-## a=gtext("this is a test for search a.",container=T)
-## b<-a@widget@widget$GetBuffer()
-## b$GetIterAtOffset(0)
-## i0=b$GetIterAtOffset(0)
-## s0=i0$iter$ForwardSearch("a","GTK_TEXT_SEARCH_VISIBLE_ONLY")
-## s0$match.start$GetOffset()
-## s0$match.end$GetOffset()
+  ## a=gtext("this is a test for search a.",container=T)
+  ## b<-a@widget@widget$GetBuffer()
+  ## b$GetIterAtOffset(0)
+  ## i0=b$GetIterAtOffset(0)
+  ## s0=i0$iter$ForwardSearch("a","GTK_TEXT_SEARCH_VISIBLE_ONLY")
+  ## s0$match.start$GetOffset()
+  ## s0$match.end$GetOffset()
 
-FileNamesWidgetMenu$"File Annotations"$handler <- function(h,...){
- if (is_projOpen(envir=.rqda,conName="qdacon")) {
- print(getAnnos())
-}}
-FileNamesWidgetMenu$"File Memo"$handler <- function(h,...){
- if (is_projOpen(envir=.rqda,conName="qdacon")) {
- MemoWidget("File",.rqda$.fnames_rqda,"source")
-## see CodeCatButton.R  for definition of MemoWidget
-}
-}
-FileNamesWidgetMenu$"Import PDF Highligts via rjpod (selector)"$handler <- function(h,...){
-    importPDFHL(engine="rjpod")
-}
-FileNamesWidgetMenu$"Import PDF Highligts via rjpod (file path)"$handler <- function(h,...){
-    fpath=ginput("Enter a pdf file path",con=T)
-    importPDFHL(file=fpath, engine="rjpod")
-}
-FileNamesWidgetMenu$"Open Selected File"$handler <- function(h,...){
-  ViewFileFun(FileNameWidget=.rqda$.fnames_rqda)
-}
-FileNamesWidgetMenu$"Open Previous Coded File"$handler <- function(h,...){
-  if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-    fname <- RQDAQuery("select name from source where id in ( select fid from coding where rowid in (select max(rowid) from coding where status=1))")$name
-    if (length(fname)!=0)  fname <- enc(fname,"UTF-8")
-    ViewFileFunHelper(FileName=fname)
+  FileNamesWidgetMenu[[gettext("File Annotations", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      print(getAnnos())
   }}
-FileNamesWidgetMenu$"Search for a Word"$handler <- function(h, ...) {
+  FileNamesWidgetMenu[[gettext("File Memo", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir=.rqda,conName="qdacon")) {
+      MemoWidget(gettext("File", domain = "R-RQDA"),.rqda$.fnames_rqda,"source")
+      ## see CodeCatButton.R  for definition of MemoWidget
+    }
+  }
+  FileNamesWidgetMenu[[gettext("Import PDF Highligts via rjpod (selector)", domain = "R-RQDA")]]$handler <- function(h,...){
+    importPDFHL(engine="rjpod")
+  }
+  FileNamesWidgetMenu[[gettext("Import PDF Highligts via rjpod (file path)", domain = "R-RQDA")]]$handler <- function(h,...){
+    fpath=ginput(gettext("Enter a pdf file path", domain = "R-RQDA"),con=T)
+    importPDFHL(file=fpath, engine="rjpod")
+  }
+  FileNamesWidgetMenu[[gettext("Open Selected File", domain = "R-RQDA")]]$handler <- function(h,...){
+    ViewFileFun(FileNameWidget=.rqda$.fnames_rqda)
+  }
+  FileNamesWidgetMenu[[gettext("Open Previous Coded File", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
+      fname <- RQDAQuery("select name from source where id in ( select fid from coding where rowid in (select max(rowid) from coding where status=1))")$name
+      if (length(fname)!=0)  fname <- enc(fname,"UTF-8")
+      ViewFileFunHelper(FileName=fname)
+  }}
+  FileNamesWidgetMenu[[gettext("Search for a Word", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (exists(".openfile_gui",envir=.rqda) && isExtant(.rqda$.openfile_gui)) {
-        SearchButton(.rqda$.openfile_gui)
+      SearchButton(.rqda$.openfile_gui)
     }
-}
-FileNamesWidgetMenu$"Search all files ..."$handler <- function(h, ...) {
+  }
+  FileNamesWidgetMenu[[gettext("Search all files ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-    pattern <- ifelse(is.null(.rqda$lastsearch),"file like '%%'",.rqda$lastsearch)
-    pattern <- ginput("Please input a search pattern.",text=pattern)
-    if (!is.na(pattern)){
-    tryCatch(SearchFiles(pattern,Widget=".fnames_rqda",is.UTF8=TRUE),error=function(e) gmessage("Error~~~."),container=TRUE)
-    Encoding(pattern) <- "UTF-8"
-    assign("lastsearch",pattern,envir=.rqda)
-    }
+      pattern <- ifelse(is.null(.rqda$lastsearch),"file like '%%'",.rqda$lastsearch)
+      pattern <- ginput(gettext("Please input a search pattern.", domain = "R-RQDA"),text=pattern)
+      if (!is.na(pattern)){
+        tryCatch(SearchFiles(pattern,Widget=".fnames_rqda",is.UTF8=TRUE),error=function(e) gmessage(gettext("Error~~~.", domain = "R-RQDA")),container=TRUE)
+        Encoding(pattern) <- "UTF-8"
+        assign("lastsearch",pattern,envir=.rqda)
+      }
     }
   }
-FileNamesWidgetMenu$"Show ..."$"Show All Sorted By Imported Time"$handler <- function(h, ...) {
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show All Sorted By Imported Time", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-     ##FileNamesUpdate(FileNamesWidget=.rqda$.fnames_rqda)
-     FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=GetFileId(condition="unconditional",type="all"))
+      ##FileNamesUpdate(FileNamesWidget=.rqda$.fnames_rqda)
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=GetFileId(condition="unconditional",type="all"))
     }
   }
-FileNamesWidgetMenu$"Show ..."$"Show Coded Files Sorted by Imported time"$handler <- function(h,...){
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=GetFileId(condition="unconditional",type="coded"))
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Coded Files Sorted by Imported time", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=GetFileId(condition="unconditional",type="coded"))
+    }
   }
-}
-FileNamesWidgetMenu$"Show ..."$"Show Uncoded Files Sorted by Imported time"$handler <- function(h, ...) {
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Uncoded Files Sorted by Imported time", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
       ## UncodedFileNamesUpdate(FileNamesWidget = .rqda$.fnames_rqda)
       FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=GetFileId(condition="unconditional",type="uncoded"))
       ## By default, the file names in the widget will be sorted.
     }
   }
-FileNamesWidgetMenu$"Show ..."$"Show Files With Annotation"$handler <- function(h, ...) {
-  fileid <- RQDAQuery("select fid from annotation where status=1 group by fid")$fid
-  if (length(fileid)!=0) {
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
-  } else gmessage("No file with memo.",container=TRUE)
-}
-FileNamesWidgetMenu$"Show ..."$"Show Files Without Annotation"$handler <- function(h, ...) {
-  fileid <- RQDAQuery("select id from source where status=1 and id not in (select fid from annotation where status=1 group by fid)")$id
-  if (length(fileid)!=0) {
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
-  } else gmessage("All files have annotation.",container=TRUE)
-}
-
-FileNamesWidgetMenu$"Show ..."$"Show Files With Memo"$handler <- function(h, ...) {
-    if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-    fileid <- dbGetQuery(.rqda$qdacon,"select id from source where memo is not null")
-    if (nrow(fileid)!=0) {
-    fileid <- fileid[[1]]
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
-    } else gmessage("No file with memo.",container=TRUE)
-    }
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Files With Annotation", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    fileid <- RQDAQuery("select fid from annotation where status=1 group by fid")$fid
+    if (length(fileid)!=0) {
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
+    } else gmessage(gettext("No file with memo.", domain = "R-RQDA"),container=TRUE)
   }
-FileNamesWidgetMenu$"Show ..."$"Show Files Without Memo"$handler <- function(h, ...) {
-    if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-    fileid <- dbGetQuery(.rqda$qdacon,"select id from source where memo is null")
-    if (nrow(fileid)!=0) {
-    fileid <- fileid[[1]]
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
-    } else gmessage("No file is found.",container=TRUE)
-    }
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Files Without Annotation", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    fileid <- RQDAQuery("select id from source where status=1 and id not in (select fid from annotation where status=1 group by fid)")$id
+    if (length(fileid)!=0) {
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
+    } else gmessage(gettext("All files have annotation.", domain = "R-RQDA"),container=TRUE)
   }
 
-FileNamesWidgetMenu$"Show ..."$"Show Files Without File Category"$handler <- function(h, ...) {
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Files With Memo", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-        fileid <- RQDAQuery("select id from source where status=1 and id not in (select fid from treefile where status=1)")
-        if (nrow(fileid)!=0) {
-            fileid <- fileid[[1]]
-            FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
-        } else gmessage("All are linked with file category.",container=TRUE)
+      fileid <- dbGetQuery(.rqda$qdacon,"select id from source where memo is not null")
+      if (nrow(fileid)!=0) {
+        fileid <- fileid[[1]]
+        FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
+      } else gmessage(gettext("No file with memo.", domain = "R-RQDA"),container=TRUE)
     }
-}
-FileNamesWidgetMenu$"Show ..."$"Show Files With No Case"$handler <- function(h, ...) {
+  }
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Files Without Memo", domain = "R-RQDA")]]$handler <- function(h, ...) {
     if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-        fileid <- RQDAQuery("select id from source where status=1 and id not in (select fid from caselinkage where status=1)")
-        if (nrow(fileid)!=0) {
-            fileid <- fileid[[1]]
-            FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
-        } else gmessage("All are linked with cases.",container=TRUE)
+      fileid <- dbGetQuery(.rqda$qdacon,"select id from source where memo is null")
+      if (nrow(fileid)!=0) {
+        fileid <- fileid[[1]]
+        FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
+      } else gmessage(gettext("No file is found.", domain = "R-RQDA"),container=TRUE)
     }
+  }
+
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Files Without File Category", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
+      fileid <- RQDAQuery("select id from source where status=1 and id not in (select fid from treefile where status=1)")
+      if (nrow(fileid)!=0) {
+        fileid <- fileid[[1]]
+        FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
+      } else gmessage(gettext("All are linked with file category.", domain = "R-RQDA"),container=TRUE)
+    }
+  }
+  FileNamesWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Files With No Case", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
+      fileid <- RQDAQuery("select id from source where status=1 and id not in (select fid from caselinkage where status=1)")
+      if (nrow(fileid)!=0) {
+        fileid <- fileid[[1]]
+        FileNameWidgetUpdate(FileNamesWidget=.rqda$.fnames_rqda,FileId=fileid)
+      } else gmessage(gettext("All are linked with cases.", domain = "R-RQDA"),container=TRUE)
+    }
+  }
+  FileNamesWidgetMenu[[gettext("Show Selected File Property", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
+      ShowFileProperty()
+    }
+  }
+  FileNamesWidgetMenu
 }
-FileNamesWidgetMenu$"Show Selected File Property"$handler <- function(h, ...) {
-  if (is_projOpen(envir = .rqda, conName = "qdacon", message = FALSE)) {
-  ShowFileProperty()
-}}

--- a/R/FileCatButton.R
+++ b/R/FileCatButton.R
@@ -1,7 +1,7 @@
 #################
-AddFileCatButton <- function(label="ADD"){
+AddFileCatButton <- function(label=gettext("ADD", domain = "R-RQDA")){
   AddFilCatB <- gbutton(label,handler=function(h,...) {
-    item <- ginput("Enter new File Category. ", icon="info")
+    item <- ginput(gettext("Enter new File Category. ", domain = "R-RQDA"), icon="info")
     if (!is.na(item)){
       Encoding(item) <- "UTF-8"
       AddTodbTable(item,"filecat",Id="catid") ## FILE CATegory
@@ -15,9 +15,9 @@ AddFileCatButton <- function(label="ADD"){
 }
 
 
-DeleteFileCatButton <- function(label="Delete"){
+DeleteFileCatButton <- function(label=gettext("Delete", domain = "R-RQDA")){
   DelFilCatB <- gbutton(label, handler=function(h,...){
-    del <- gconfirm("Really delete the File Category?",icon="question")
+    del <- gconfirm(gettext("Really delete the File Category?", domain = "R-RQDA"),icon="question")
     if (isTRUE(del)){
       Selected <- svalue(.rqda$.FileCatWidget)
       Encoding(Selected) <- "UTF-8"
@@ -29,7 +29,7 @@ DeleteFileCatButton <- function(label="Delete"){
         tryCatch(dbGetQuery(.rqda$qdacon,sprintf("update treefile set status=0 where catid='%s'",catid)),error=function(e){})
         ## should delete all the related codelists
         UpdateFileofCatWidget() ## update files of file cat widget
-      } else gmessage("The Category Name is not unique.",con=TRUE)
+      } else gmessage(gettext("The Category Name is not unique.", domain = "R-RQDA"),con=TRUE)
     }
   }
                         )
@@ -39,13 +39,13 @@ DeleteFileCatButton <- function(label="Delete"){
 }
 
 
-FileCat_RenameButton <- function(label="Rename",Widget=.rqda$.FileCatWidget,...)
+FileCat_RenameButton <- function(label=gettext("Rename", domain = "R-RQDA"),Widget=.rqda$.FileCatWidget,...)
 {
   ## rename of selected file cat.
   FilCatRenB <- gbutton(label,handler=function(h,...) {
     OldName <- svalue(Widget)
     ## get the new file names
-    NewName <- ginput("Enter new Cateory name. ",text=OldName, icon="info")
+    NewName <- ginput(gettext("Enter new Cateory name. ", domain = "R-RQDA"),text=OldName, icon="info")
     if (!is.na(NewName)) {
       Encoding(NewName) <- "UTF-8"
       rename(OldName,NewName,"filecat")
@@ -94,25 +94,25 @@ UpdateFileofCatWidget2 <- function(con=.rqda$qdacon,Widget=.rqda$.FileofCat,sort
 
 
 
-FileCatMemoButton <- function(label="Memo"){
+FileCatMemoButton <- function(label=gettext("Memo", domain = "R-RQDA")){
   ans <- gbutton(label,handler=function(h,...) {
-    MemoWidget("File Category",.rqda$.FileCatWidget,"filecat")
+    MemoWidget(gettext("File Category", domain = "R-RQDA"),.rqda$.FileCatWidget,"filecat")
     }
                  )
-  gtkWidgetSetTooltipText(getToolkitWidget(ans),"Memo of file category.")
+  gtkWidgetSetTooltipText(getToolkitWidget(ans), gettext("Memo of file category.", domain = "R-RQDA"))
   assign("FilCatMemB",ans,button)
   enabled(ans) <- FALSE
   ans
 }
 
 
-FileCatAddToButton <- function(label="AddTo",Widget=.rqda$.FileCatWidget,...)
+FileCatAddToButton <- function(label=gettext("AddTo", domain = "R-RQDA"),Widget=.rqda$.FileCatWidget,...)
 {
   ans <- gbutton(label,handler=function(h,...) {
     SelectedFileCat <- svalue(.rqda$.FileCatWidget)
     catid <- dbGetQuery(.rqda$qdacon,sprintf("select catid from filecat where status=1 and name='%s'",enc(SelectedFileCat)))[,1]
     freefile <-  dbGetQuery(.rqda$qdacon,"select name, id from source where status=1")
-    if (nrow(freefile) == 0){gmessage("No files Yet.",cont=.rqda$.FileCatWidget)} else {
+    if (nrow(freefile) == 0){gmessage(gettext("No files Yet.", domain = "R-RQDA"),cont=.rqda$.FileCatWidget)} else {
       Encoding(SelectedFileCat) <- Encoding(freefile[['name']]) <- "UTF-8"
       fileofcat <- dbGetQuery(.rqda$qdacon,sprintf("select fid from treefile where status=1 and catid=%i",catid))
       if (nrow(fileofcat)!=0){
@@ -129,18 +129,18 @@ FileCatAddToButton <- function(label="AddTo",Widget=.rqda$.FileCatWidget,...)
     }
   }
                  )
-  gtkWidgetSetTooltipText(getToolkitWidget(ans),"Add file(s) to the selected file category.")
+  gtkWidgetSetTooltipText(getToolkitWidget(ans), gettext("Add file(s) to the selected file category.", domain = "R-RQDA"))
   assign("FilCatAddToB",ans,button)
   enabled(ans) <- FALSE
   return(ans)
 }
 
-FileCatDropFromButton <- function(label="DropFrom",Widget=.rqda$.FileofCat,...)
+FileCatDropFromButton <- function(label=gettext("DropFrom", domain = "R-RQDA"),Widget=.rqda$.FileofCat,...)
 {
   ans <- gbutton(label,handler=function(h,...) {
     FileOfCat <- svalue(Widget)
     ## Give a confirm msg
-    del <- gconfirm(sprintf("Delete %i file(s) from this category. Are you sure?",length(FileOfCat)),con=TRUE,icon="question")
+    del <- gconfirm(sprintf(gettext("Delete %i file(s) from this category. Are you sure?", domain = "R-RQDA"),length(FileOfCat)),con=TRUE,icon="question")
     if (isTRUE(del)){
       SelectedFileCat <- svalue(.rqda$.FileCatWidget)
       Encoding(SelectedFileCat) <- Encoding(FileOfCat)<- "UTF-8"
@@ -156,7 +156,7 @@ FileCatDropFromButton <- function(label="DropFrom",Widget=.rqda$.FileofCat,...)
     }
   }
                  )
-  gtkWidgetSetTooltipText(getToolkitWidget(ans),"Drop selected file(s) from file category.")
+  gtkWidgetSetTooltipText(getToolkitWidget(ans), gettext("Drop selected file(s) from file category.", domain = "R-RQDA"))
   assign("FilCatDroFromB",ans,button)
   enabled(ans) <- FALSE
   return(ans)
@@ -175,7 +175,7 @@ FileCatDropFromButton <- function(label="DropFrom",Widget=.rqda$.FileofCat,...)
 
 ##   ## select a F-cat name -> F-cat id
 ##   Fcat <- dbGetQuery(.rqda$qdacon,"select catid, name from filecat where status=1")
-##   if (nrow(Fcat)==0){gmessage("Add File Categroy first.",con=TRUE)} else{
+##   if (nrow(Fcat)==0){gmessage(gettext("Add File Categroy first.", domain = "R-RQDA"),con=TRUE)} else{
 ##     Encoding(Fcat$name) <- "UTF-8"
 ##     ##ans <- select.list(Fcat$name,multiple=FALSE)
 ##     CurrentFrame <- sys.frame(sys.nframe())
@@ -193,158 +193,166 @@ FileCatDropFromButton <- function(label="DropFrom",Widget=.rqda$.FileofCat,...)
 ##       if (success) {
 ##       UpdateFileofCatWidget()
 ##       }
-##       if (!success) gmessage("Fail to write to database.")
+##       if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
 ##     }}})}}
 
 
-
-FileCatWidgetMenu <- list()
-FileCatWidgetMenu$Memo$handler <- function(h,...){
- if (is_projOpen(env=.rqda,conName="qdacon")) {
-   MemoWidget("File Category",.rqda$.FileCatWidget,"filecat")
-   ## see CodeCatButton.R  for definition of MemoWidget
- }
-}
-FileCatWidgetMenu$"Delete all files of selected category"$handler <- function(h,...){
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    fid <- GetFileId("file")
-    if (length(fid)>0){
-      dbGetQuery(.rqda$qdacon, sprintf("update source set status=0 where id in (%s)",paste(shQuote(fid),collapse=",")))
-      dbGetQuery(.rqda$qdacon, sprintf("update coding set status=0 where fid in (%s)",paste(shQuote(fid),collapse=",")))
-      dbGetQuery(.rqda$qdacon, sprintf("update caselinkage set status=0 where fid in (%s)",paste(shQuote(fid),collapse=",")))
-      dbGetQuery(.rqda$qdacon, sprintf("update treefile set status=0 where fid in (%s)",paste(shQuote(fid),collapse=",")))
-      UpdateFileofCatWidget()
+GetFileCatWidgetMenu <- function()
+{
+  FileCatWidgetMenu <- list()
+  FileCatWidgetMenu[[gettext("Memo", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      MemoWidget(gettext("File Category", domain = "R-RQDA"),.rqda$.FileCatWidget,"filecat")
+      ## see CodeCatButton.R  for definition of MemoWidget
     }
   }
-}
-FileCatWidgetMenu$"Sort by created time"$handler <- function(h,...)
-{
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    UpdateTableWidget(Widget=.rqda$.FileCatWidget,FromdbTable="filecat")
+  FileCatWidgetMenu[[gettext("Delete all files of selected category", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      fid <- GetFileId("file")
+      if (length(fid)>0){
+        dbGetQuery(.rqda$qdacon, sprintf("update source set status=0 where id in (%s)",paste(shQuote(fid),collapse=",")))
+        dbGetQuery(.rqda$qdacon, sprintf("update coding set status=0 where fid in (%s)",paste(shQuote(fid),collapse=",")))
+        dbGetQuery(.rqda$qdacon, sprintf("update caselinkage set status=0 where fid in (%s)",paste(shQuote(fid),collapse=",")))
+        dbGetQuery(.rqda$qdacon, sprintf("update treefile set status=0 where fid in (%s)",paste(shQuote(fid),collapse=",")))
+        UpdateFileofCatWidget()
+      }
+    }
   }
+  FileCatWidgetMenu[[gettext("Sort by created time", domain = "R-RQDA")]]$handler <- function(h,...)
+  {
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      UpdateTableWidget(Widget=.rqda$.FileCatWidget,FromdbTable="filecat")
+    }
+  }
+  FileCatWidgetMenu
 }
 
 
 ## popup menu for files of this category
-FileofCatWidgetMenu <- list()
-FileofCatWidgetMenu$"Add To Case ..."$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+GetFileofCatWidgetMenu <- function()
+{
+  FileofCatWidgetMenu <- list()
+  FileofCatWidgetMenu[[gettext("Add To Case ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
       AddFileToCaselinkage(Widget=.rqda$.FileofCat)
       UpdateFileofCaseWidget()
     }
-}
-FileofCatWidgetMenu$"Add To File Category ..."$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    AddToFileCategory(Widget=.rqda$.FileofCat,updateWidget=FALSE)
   }
-}
-FileofCatWidgetMenu$"Move To File Category ..."$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    fcatname <- svalue(.rqda$.FileCatWidget) ## should select one only
-    fcatid <- dbGetQuery(.rqda$qdacon,sprintf("select catid from filecat where name='%s'",
-                                              enc(fcatname)))$catid
-    fid <- GetFileId("file","select")
-    ans <- AddToFileCategory(Widget=.rqda$.FileofCat,updateWidget=FALSE)
-    if (isTRUE(ans)) {
-      dbGetQuery(.rqda$qdacon,sprintf("update treefile set status=0 where fid in (%s) and catid='%s'",
-                                      paste(shQuote(fid),collapse=","),
-                                      fcatid))
-      .rqda$.FileofCat[] <- setdiff(.rqda$.FileofCat[],svalue(.rqda$.FileofCat))
+  FileofCatWidgetMenu[[gettext("Add To File Category ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      AddToFileCategory(Widget=.rqda$.FileofCat,updateWidget=FALSE)
+    }
+  }
+  FileofCatWidgetMenu[[gettext("Move To File Category ...", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      fcatname <- svalue(.rqda$.FileCatWidget) ## should select one only
+      fcatid <- dbGetQuery(.rqda$qdacon,sprintf("select catid from filecat where name='%s'",
+                                                enc(fcatname)))$catid
+      fid <- GetFileId("file","select")
+      ans <- AddToFileCategory(Widget=.rqda$.FileofCat,updateWidget=FALSE)
+      if (isTRUE(ans)) {
+        dbGetQuery(.rqda$qdacon,sprintf("update treefile set status=0 where fid in (%s) and catid='%s'",
+                                        paste(shQuote(fid),collapse=","),
+                                        fcatid))
+        .rqda$.FileofCat[] <- setdiff(.rqda$.FileofCat[],svalue(.rqda$.FileofCat))
     }}
   }
-FileofCatWidgetMenu$"File Memo"$handler <- function(h,...){
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    MemoWidget("File",.rqda$.FileofCat,"source")
+  FileofCatWidgetMenu[[gettext("File Memo", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      MemoWidget(gettext("File", domain = "R-RQDA"),.rqda$.FileofCat,"source")
+    }
   }
-}
-FileofCatWidgetMenu$"Open Selected File"$handler <- function(h,...){
-  ViewFileFun(FileNameWidget=.rqda$.FileofCat)
-}
-FileofCatWidgetMenu$"Edit Selected File"$handler <- function(h,...){
-  EditFileFun(FileNameWidget=.rqda$.FileofCat)
-}
-FileofCatWidgetMenu$"Search Files Within Categroy"$handler <- function(h,...)
-{
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
+  FileofCatWidgetMenu[[gettext("Open Selected File", domain = "R-RQDA")]]$handler <- function(h,...){
+    ViewFileFun(FileNameWidget=.rqda$.FileofCat)
+  }
+  FileofCatWidgetMenu[[gettext("Edit Selected File", domain = "R-RQDA")]]$handler <- function(h,...){
+    EditFileFun(FileNameWidget=.rqda$.FileofCat)
+  }
+  FileofCatWidgetMenu[[gettext("Search Files Within Categroy", domain = "R-RQDA")]]$handler <- function(h,...)
+  {
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
       fid <- GetFileId(condition="filecategory",type="all")
       pattern <- ifelse(is.null(.rqda$lastsearch),"file like '%%'",.rqda$lastsearch)
-      pattern <- ginput("Please input a search pattern.",text=pattern)
+      pattern <- ginput(gettext("Please input a search pattern.", domain = "R-RQDA"),text=pattern)
       Encoding(pattern)<- "UTF-8"
       if (!is.na(pattern) && length(fid)!=0){
-          tryCatch(SearchFiles(sprintf("(%s) and id in (%s)",pattern,paste(shQuote(fid),collapse=",")),
-                               Widget=".FileofCat",is.UTF8=TRUE),
-                   error=function(e) gmessage("Error~~~."),con=TRUE)
-          assign("lastsearch",pattern,env=.rqda)
+        tryCatch(SearchFiles(sprintf("(%s) and id in (%s)",pattern,paste(shQuote(fid),collapse=",")),
+                             Widget=".FileofCat",is.UTF8=TRUE),
+                 error=function(e) gmessage(gettext("Error~~~.", domain = "R-RQDA")),con=TRUE)
+        assign("lastsearch",pattern,env=.rqda)
       }
-  }
-}
-FileofCatWidgetMenu$"Delete selected File(s)"$handler <- function(h,...){
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    SelectedFile <- svalue(.rqda$.FileofCat)
-    Encoding(SelectedFile) <- "UTF-8"
-    for (i in SelectedFile){
-      i <- enc(i)
-      fid <- dbGetQuery(.rqda$qdacon, sprintf("select id from source where name='%s'",i))$id
-      dbGetQuery(.rqda$qdacon, sprintf("update source set status=0 where name='%s'",i))
-      dbGetQuery(.rqda$qdacon, sprintf("update caselinkage set status=0 where fid=%i",fid))
-      dbGetQuery(.rqda$qdacon, sprintf("update treefile set status=0 where fid=%i",fid))
-      dbGetQuery(.rqda$qdacon, sprintf("update coding set status=0 where fid=%i",fid))
     }
-    ## UpdateFileofCatWidget()
-    ## .rqda$.FileofCat[] <- setdiff(.rqda$.FileofCat[],SelectedFile)
-    UpdateWidget(".FileofCat",from=SelectedFile,to=NULL)
   }
-}
-FileofCatWidgetMenu$"Rename selected File"$handler <- function(h,...){
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    selectedFN <- svalue(.rqda$.FileofCat)
-    if (length(selectedFN)==0){
-      gmessage("Select a file first.",icon="error",con=TRUE)
-    }
-    else {
-      NewFileName <- ginput("Enter new file name. ",text=selectedFN, icon="info")
-      if (!is.na(NewFileName)) {
-        Encoding(NewFileName) <- "UTF-8"
-        rename(selectedFN,NewFileName,"source")
-        ## UpdateFileofCatWidget()
-        Fnames <- .rqda$.FileofCat[]
-        Fnames[Fnames==selectedFN] <- NewFileName
-        .rqda$.FileofCat[] <- Fnames
+  FileofCatWidgetMenu[[gettext("Delete selected File(s)", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      SelectedFile <- svalue(.rqda$.FileofCat)
+      Encoding(SelectedFile) <- "UTF-8"
+      for (i in SelectedFile){
+        i <- enc(i)
+        fid <- dbGetQuery(.rqda$qdacon, sprintf("select id from source where name='%s'",i))$id
+        dbGetQuery(.rqda$qdacon, sprintf("update source set status=0 where name='%s'",i))
+        dbGetQuery(.rqda$qdacon, sprintf("update caselinkage set status=0 where fid=%i",fid))
+        dbGetQuery(.rqda$qdacon, sprintf("update treefile set status=0 where fid=%i",fid))
+        dbGetQuery(.rqda$qdacon, sprintf("update coding set status=0 where fid=%i",fid))
       }
-    }}}
-## FileofCatWidgetMenu$"Show ..."$"Show Uncoded Files Only Sorted By Imported Time"$handler <- function(h,...){
-##  if (is_projOpen(env=.rqda,conName="qdacon")) {
-##    fid <- GetFileId(condition="filecategory",type="uncoded")
-##    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=fid)
-##  }
-## }
-## FileofCatWidgetMenu$"Show ..."$"Show Coded Files Only Sorted By Imported Time"$handler <- function(h,...){
-##   if (is_projOpen(env=.rqda,conName="qdacon")) {
-##     fid <- GetFileId(condition="filecategory",type="coded")
-##     FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=fid)
-##   }
-## }
-FileofCatWidgetMenu$"Show ..."$"Show All By Imported Time"$handler <- function(h,...)
-{
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    fid <- GetFileId(condition="filecategory",type="all")
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=fid)
+      ## UpdateFileofCatWidget()
+      ## .rqda$.FileofCat[] <- setdiff(.rqda$.FileofCat[],SelectedFile)
+      UpdateWidget(".FileofCat",from=SelectedFile,to=NULL)
+    }
   }
-}
-FileofCatWidgetMenu$"Show ..."$"Show Coded Files Sorted by Imported time"$handler <- function(h,...){
-  if (is_projOpen(env=.rqda,conName="qdacon")) {
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=GetFileId(condition="filecat",type="coded"))
+  FileofCatWidgetMenu[[gettext("Rename selected File", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      selectedFN <- svalue(.rqda$.FileofCat)
+      if (length(selectedFN)==0){
+        gmessage(gettext("Select a file first.", domain = "R-RQDA"),icon="error",con=TRUE)
+      }
+      else {
+        NewFileName <- ginput(gettext("Enter new file name. ", domain = "R-RQDA"),text=selectedFN, icon="info")
+        if (!is.na(NewFileName)) {
+          Encoding(NewFileName) <- "UTF-8"
+          rename(selectedFN,NewFileName,"source")
+          ## UpdateFileofCatWidget()
+          Fnames <- .rqda$.FileofCat[]
+          Fnames[Fnames==selectedFN] <- NewFileName
+          .rqda$.FileofCat[] <- Fnames
+        }
+  }}}
+  ## FileofCatWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Uncoded Files Only Sorted By Imported Time", domain = "R-RQDA")]]$handler <- function(h,...){
+  ##  if (is_projOpen(env=.rqda,conName="qdacon")) {
+  ##    fid <- GetFileId(condition="filecategory",type="uncoded")
+  ##    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=fid)
+  ##  }
+  ## }
+  ## FileofCatWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Coded Files Only Sorted By Imported Time", domain = "R-RQDA")]]$handler <- function(h,...){
+  ##   if (is_projOpen(env=.rqda,conName="qdacon")) {
+  ##     fid <- GetFileId(condition="filecategory",type="coded")
+  ##     FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=fid)
+  ##   }
+  ## }
+  FileofCatWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show All By Imported Time", domain = "R-RQDA")]]$handler <- function(h,...)
+  {
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      fid <- GetFileId(condition="filecategory",type="all")
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=fid)
+    }
   }
-}
-FileofCatWidgetMenu$"Show ..."$"Show Uncoded Files Sorted by Imported time"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    ## UncodedFileNamesUpdate(FileNamesWidget = .rqda$.fnames_rqda)
-    FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=GetFileId(condition="filecat",type="uncoded"))
-    ## By default, the file names in the widget will be sorted.
+  FileofCatWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Coded Files Sorted by Imported time", domain = "R-RQDA")]]$handler <- function(h,...){
+    if (is_projOpen(env=.rqda,conName="qdacon")) {
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=GetFileId(condition="filecat",type="coded"))
+    }
   }
+  FileofCatWidgetMenu[[gettext("Show ...", domain = "R-RQDA")]][[gettext("Show Uncoded Files Sorted by Imported time", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      ## UncodedFileNamesUpdate(FileNamesWidget = .rqda$.fnames_rqda)
+      FileNameWidgetUpdate(FileNamesWidget=.rqda$.FileofCat,FileId=GetFileId(condition="filecat",type="uncoded"))
+      ## By default, the file names in the widget will be sorted.
+    }
+  }
+  FileofCatWidgetMenu[[gettext("Show Selected File Property", domain = "R-RQDA")]]$handler <- function(h, ...) {
+    if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
+      ShowFileProperty(Fid=GetFileId("filecat","selected"))
+    }
+  }
+  FileofCatWidgetMenu
 }
-FileofCatWidgetMenu$"Show Selected File Property"$handler <- function(h, ...) {
-  if (is_projOpen(env = .rqda, conName = "qdacon", message = FALSE)) {
-    ShowFileProperty(Fid=GetFileId("filecat","selected"))
-}}
 

--- a/R/FilesFun.R
+++ b/R/FilesFun.R
@@ -25,7 +25,7 @@ ImportFile <- function(path,encoding=.rqda$encoding,con=.rqda$qdacon,...){
         ## no duplication file exists, then write.
         write <- TRUE
       } else {
-        gmessage("A file withe the same name exists in the database!")
+        gmessage(gettext("A file with the same name exists in the database!", domain = "R-RQDA"))
       }
     }
     if (write ) {
@@ -94,7 +94,7 @@ ViewFileFun <- function(FileNameWidget,hightlight=TRUE){
     ## FileNameWidget=.rqda$.FileofCat in F-CAT Tab
     if (is_projOpen(envir = .rqda, conName = "qdacon")) {
         if (length(svalue(FileNameWidget)) == 0) {
-            gmessage("Select a file first.", icon = "error",con = TRUE)
+            gmessage(gettext("Select a file first.", domain = "R-RQDA"), icon = "error",con = TRUE)
         } else {
             SelectedFileName <- svalue(FileNameWidget)
             ViewFileFunHelper(SelectedFileName,hightlight=TRUE)
@@ -226,7 +226,7 @@ EditFileFun <- function(FileNameWidget=.rqda$.fnames_rqda){
   if (is_projOpen(envir=.rqda, conName = "qdacon")) {
     SelectedFileName <- svalue(FileNameWidget)
     if (length(svalue(FileNameWidget)) == 0) {
-      gmessage("Select a file first.", icon = "error", con = TRUE)
+      gmessage(gettext("Select a file first.", domain = "R-RQDA"), icon = "error", con = TRUE)
     }
     else {
       tryCatch(dispose(.rqda$.root_edit),error=function(e) {})
@@ -237,7 +237,7 @@ EditFileFun <- function(FileNameWidget=.rqda$.fnames_rqda){
       gw@widget@widget$SetIconFromFile(mainIcon)
       assign(".root_edit",gw,envir=.rqda)
       assign(".root_edit2",gpanedgroup(horizontal = FALSE, container=.rqda$.root_edit),envir=.rqda)
-      EdiFilB <- gbutton("Save File",container=.rqda$.root_edit2,handler=function(h,...){
+      EdiFilB <- gbutton(gettext("Save File", domain = "R-RQDA"),container=.rqda$.root_edit2,handler=function(h,...){
         content <-  svalue(.rqda$.openfile_gui)
         RQDAQuery(sprintf("update source set file='%s', dateM='%s' where name='%s'",
                           enc(content,"UTF-8"),date(),enc(svalue(.rqda$.root_edit),"UTF-8"))) ## update source table
@@ -406,7 +406,7 @@ write.FileList <- function(FileList,encoding=.rqda$encoding,con=.rqda$qdacon,...
       WriteToTable(FileNames[i],FileList[[i]])
     }
     FileNamesUpdate(FileNamesWidget=.rqda$.fnames_rqda)
-    } else gmessage("Open a project first.", container=TRUE)
+    } else gmessage(gettext("Open a project first.", domain = "R-RQDA"), container=TRUE)
 }
 
 addFilesFromDir <- function(dir, pattern = "*.txt$"){
@@ -435,7 +435,7 @@ ProjectMemoWidget <- function(){
     .projmemo <- get(".projmemo",.rqda)
     .projmemo2 <- gpanedgroup(horizontal = FALSE, container=.projmemo)
     ## use .projmemo2, so can add a save button to it.
-    gbutton("Save memo",container=.projmemo2,handler=function(h,...){
+    gbutton(gettext("Save memo", domain = "R-RQDA"),container=.projmemo2,handler=function(h,...){
       ## send the new content of memo back to database
       newcontent <- svalue(W)
       ## Encoding(newcontent) <- "UTF-8"
@@ -532,8 +532,8 @@ GetFileId <- function(condition=c("unconditional","case","filecategory","both"),
       if (length(Selected)==0){
         ans <- NULL
       } else {
-        if (length(Selected)>1) {gmessage("select one file category only.",container=TRUE)
-                                 stop("more than one file categories are selected")
+        if (length(Selected)>1) {gmessage(gettext("select one file category only.", domain = "R-RQDA"),container=TRUE)
+                                 stop("more than one file categories are selected", domain = "R-RQDA")
                                }
         caseid <- RQDAQuery(sprintf("select id from cases where status=1 and name='%s'",
                                     enc(Selected)))$id
@@ -630,7 +630,7 @@ AddToFileCategory <- function(Widget=.rqda$.fnames_rqda,updateWidget=TRUE){
   Encoding(query$file) <- "UTF-8"
   ## select a F-cat name -> F-cat id
   Fcat <- dbGetQuery(.rqda$qdacon,"select catid, name from filecat where status=1")
-  if (nrow(Fcat)==0){gmessage("Add File Categroy first.",container=TRUE)} else{
+  if (nrow(Fcat)==0){gmessage(gettext("Add File Categroy first.", domain = "R-RQDA"),container=TRUE)} else{
     Encoding(Fcat$name) <- "UTF-8"
     Selecteds <- gselect.list(Fcat$name,multiple=TRUE)
     if (length(Selecteds)>0 && Selecteds!=""){
@@ -647,7 +647,7 @@ AddToFileCategory <- function(Widget=.rqda$.fnames_rqda,updateWidget=TRUE){
           if (success && updateWidget) {
             UpdateFileofCatWidget()
           }
-          if (!success) gmessage(sprintf("Fail to write to file category of %s",Selected))
+          if (!success) gmessage(sprintf(gettext("Fail to write to file category of %s", domain = "R-RQDA"),Selected))
         }
       }
     } else {
@@ -669,7 +669,7 @@ searchWord <- function(str,widget,from=0,col="green", verbose=FALSE){
         buffer$ApplyTagByName(sprintf("%s.background", col),ans$match.start, ans$match.end)
         ans$match.end$GetOffset()
     } else {
-        if (verbose) gmessage("Reach the end.")
+        if (verbose) gmessage(gettext("Reach the end.", domain = "R-RQDA"))
         invisible(NULL)
     }
 }
@@ -679,14 +679,14 @@ SearchButton <- function(widget){
     assign("searchFrom",0,envir=.rqda)
     group <- ggroup(horizontal=FALSE, container=gwindow(width=50,height=20,title="Search a word"))
     kwdW <- gedit("", container=group)
-    gbutton("Search next", container = group,handler=function(h,...){
+    gbutton(gettext("Search next", domain = "R-RQDA"), container = group,handler=function(h,...){
         if (!is.null(.rqda$searchFrom)){
             str <- svalue(h$action)
             Encoding(str) <- "UTF-8"
             res <- searchWord(str,widget=widget,from=.rqda$searchFrom, verbose=TRUE)
             assign("searchFrom",res,envir=.rqda)
         }},action=kwdW)
-     gbutton("Restart", container = group,handler=function(h,...){
+     gbutton(gettext("Restart", domain = "R-RQDA"), container = group,handler=function(h,...){
          assign("searchFrom",0,envir=.rqda)
      })
 }
@@ -696,7 +696,7 @@ SearchButton <- function(widget){
 viewPlainFile <- function(FileNameWidget=.rqda$.fnames_rqda){
     if (is_projOpen(envir= .rqda, conName = "qdacon")) {
         if (length(svalue(FileNameWidget)) == 0) {
-            gmessage("Select a file first.", icon = "error",con = TRUE)
+            gmessage(gettext("Select a file first.", domain = "R-RQDA"), icon = "error",con = TRUE)
         } else {
             SelectedFileName <- svalue(FileNameWidget)
 

--- a/R/Journal.R
+++ b/R/Journal.R
@@ -1,4 +1,4 @@
-AddJournalButton <- function(label="ADD"){
+AddJournalButton <- function(label=gettext("ADD", domain = "R-RQDA")){
   AddJouB <- gbutton(label,handler=function(h,...) {
         AddNewJournalFun()
     }
@@ -8,9 +8,9 @@ AddJournalButton <- function(label="ADD"){
   AddJouB
 }
 
-DeleteJournalButton <- function(label="Delete"){
+DeleteJournalButton <- function(label=gettext("Delete", domain = "R-RQDA")){
   DelJouB <- gbutton(label,handler=function(h,...) {
-        del <- gconfirm("Really delete the journal?",icon="question")
+        del <- gconfirm(gettext("Really delete the journal?", domain = "R-RQDA"),icon="question")
         if (isTRUE(del)){
           Selected <- svalue(.rqda$.JournalNamesWidget)
           Encoding(Selected) <- "UTF-8"
@@ -24,11 +24,11 @@ DeleteJournalButton <- function(label="Delete"){
   DelJouB
 }
 
-RenameJournalButton <- function(label="Rename")
+RenameJournalButton <- function(label=gettext("Rename", domain = "R-RQDA"))
 {
   RenJouB <- gbutton(label,handler=function(h,...) {
       selected <- svalue(.rqda$.JournalNamesWidget)
-      NewName <- ginput("Enter new journal name. ",text=substring(selected,20), icon="info")
+      NewName <- ginput(gettext("Enter new journal name. ", domain = "R-RQDA"),text=substring(selected,20), icon="info")
       Encoding(NewName) <- "UTF-8"
       NewName <- paste(substring(selected,0 ,19), NewName, sep=" ")
         if (!is.na(NewName)) {
@@ -43,7 +43,7 @@ RenameJournalButton <- function(label="Rename")
 }
 
 
-OpenJournalButton <- function(label="Open")
+OpenJournalButton <- function(label=gettext("Open", domain = "R-RQDA"))
 {
   OpeJouB <- gbutton(label,handler=function(h,...) {
       ViewJournalWidget()
@@ -78,8 +78,8 @@ AddNewJournalFun <- function(){
         gw@widget@widget$SetIconFromFile(mainIcon)
         assign(".AddNewJournalWidget",gw,envir=.rqda)
         assign(".AddNewJournalWidget2",gpanedgroup(horizontal = FALSE, container=get(".AddNewJournalWidget",envir=.rqda)),envir=.rqda)
-        gbutton("Save Journal",container=get(".AddNewJournalWidget2",envir=.rqda),handler=function(h,...){
-            ## title <- ginput("Enter new file name. ",text=Sys.time(), icon="info")
+        gbutton(gettext("Save Journal", domain = "R-RQDA"),container=get(".AddNewJournalWidget2",envir=.rqda),handler=function(h,...){
+            ## title <- ginput(gettext("Enter new file name. ", domain = "R-RQDA"),text=Sys.time(), icon="info")
             title <- as.character(Sys.time())
             if (!is.na(title)){
             if (nrow(dbGetQuery(.rqda$qdacon,sprintf("select name from journal where name='%s'",enc(title))))!=0) {
@@ -92,7 +92,7 @@ AddNewJournalFun <- function(){
                                                    enc(title), content, date(),.rqda$owner,1))
             if (is.null(ans)) {
                 dispose(.rqda$.AddNewJournalWidget)
-                ##gmessage("Succeed.",container=TRUE)
+                ##gmessage(gettext("Succeed.", domain = "R-RQDA"),container=TRUE)
             }
             ## must put here rather than in AddJournalButton()
             JournalNamesUpdate()
@@ -109,7 +109,7 @@ ViewJournalWidget <- function(prefix="Journal",widget=.rqda$.JournalNamesWidget,
   if (is_projOpen(envir=.rqda,"qdacon")) {
       Selected <- svalue(widget)
       if (length(Selected)==0){
-        gmessage("Select first.",icon="error",container=TRUE)
+        gmessage(gettext("Select first.", domain = "R-RQDA"),icon="error",container=TRUE)
       }
       else {
         tryCatch(eval(parse(text=sprintf("dispose(.rqda$.%smemo)",prefix))),error=function(e) {})
@@ -122,7 +122,7 @@ ViewJournalWidget <- function(prefix="Journal",widget=.rqda$.JournalNamesWidget,
         assign(sprintf(".%smemo2",prefix),
                gpanedgroup(horizontal = FALSE, container=get(sprintf(".%smemo",prefix),envir=.rqda)),
                envir=.rqda)
-        saveJournalButton <- gbutton("Save Journal",container=get(sprintf(".%smemo2",prefix),envir=.rqda),handler=function(h,...){
+        saveJournalButton <- gbutton(gettext("Save Journal", domain = "R-RQDA"),container=get(sprintf(".%smemo2",prefix),envir=.rqda),handler=function(h,...){
             newcontent <- svalue(W)
             newcontent <- enc(newcontent,encoding="UTF-8") ## take care of double quote.
             Encoding(Selected) <- "UTF-8"
@@ -149,7 +149,7 @@ ViewJournalWidget <- function(prefix="Journal",widget=.rqda$.JournalNamesWidget,
             InRQDA <- dbGetQuery(.rqda$qdacon, sprintf("select journal from %s where name='%s'",dbTable, enc(Selected)))[1, 1]
             if (isTRUE(all.equal(withinWidget,InRQDA))) {
                 return(FALSE) } else {
-                    val <- gconfirm("The Journal has bee changed, Close anyway?",container=TRUE)
+                    val <- gconfirm(gettext("The Journal has been changed. Close anyway?", domain = "R-RQDA"),container=TRUE)
                     return(!val)
                 }
         }

--- a/R/Profile_Matrix.R
+++ b/R/Profile_Matrix.R
@@ -14,7 +14,7 @@ prof_mat <- function(unit = c("coding", "file"), case_ids = NULL, case_names = N
     Encoding(codes$name) <- "UTF-8"
     
     wnh <- size(.rqda$.root_rqdagui)  
-    w <- gwindow(title=sprintf("Profile Matrix - %s", unit), height=(gdkScreenHeight()-100), width=500,visible=FALSE, parent = c(wnh[1]+10, 2))
+    w <- gwindow(title=sprintf(gettext("Profile Matrix - %s", domain = "R-RQDA"), unit), height=(gdkScreenHeight()-100), width=500,visible=FALSE, parent = c(wnh[1]+10, 2))
     gf <- ggroup(container=w, use.scrollwindow=TRUE)
     tbl <- glayout(container = gf, expand=FALSE)
 

--- a/R/ProjectButton.R
+++ b/R/ProjectButton.R
@@ -1,6 +1,6 @@
 NewProjectButton <- function(container){
-  gbutton("New Project",container=container,handler=function(h,...){
-    path=gfile(type="save",text = "Type a name for the new project and click OK.")
+  gbutton(gettext("New Project", domain = "R-RQDA"),container=container,handler=function(h,...){
+    path=gfile(type="save",text = gettext("Type a name for the new project and click OK.", domain = "R-RQDA"))
     if (Encoding(path) != "UTF-8") {
         Encoding(path) <- "UTF-8"
     }
@@ -40,9 +40,9 @@ NewProjectButton <- function(container){
 }
 
 OpenProjectButton <- function(container){
-  gbutton("Open Project",container=container,handler=function(h,...){
-    path <- gfile(text = "Select a *.rqda file and click OK.",type="open",
-                  filter=list("rqda"=list(patterns = c("*.rqda")),"All files" = list(patterns = c("*"))))
+  gbutton(gettext("Open Project", domain = "R-RQDA"),container=container,handler=function(h,...){
+    path <- gfile(text = gettext("Select a *.rqda file and click OK.", domain = "R-RQDA"),type="open",
+                  filter=list("rqda"=list(patterns = c("*.rqda")), "All files" = list(patterns = c("*"))))
     if (!is.na(path)){
       Encoding(path) <- "UTF-8"
       openProject(path,updateGUI=TRUE)
@@ -65,7 +65,7 @@ openProject <- function(path,updateGUI=FALSE) {
     ## close currect project before open a new one.
     open_proj(path,assignenv=.rqda)
     if (updateGUI) {
-        svalue(.rqda$.currentProj) <- "Opening ..."
+        svalue(.rqda$.currentProj) <- gettext("Opening ...", domain = "R-RQDA")
         UpgradeTables()
         tryCatch(CodeNamesUpdate(sortByTime=FALSE),error=function(e){})
         tryCatch(FileNamesUpdate(sortByTime=FALSE),error=function(e){})
@@ -107,7 +107,7 @@ openProject <- function(path,updateGUI=FALSE) {
 }
 
 closeProjBF <- function(){
-    svalue(.rqda$.currentProj) <- "Closing ..."
+    svalue(.rqda$.currentProj) <- gettext("Closing ...", domain = "R-RQDA")
     tryCatch(.rqda$.codes_rqda[]<-NULL,error=function(e){})
     tryCatch(.rqda$.fnames_rqda[]<-NULL,error=function(e){})
     tryCatch(.rqda$.CasesNamesWidget[]<-NULL,error=function(e){})
@@ -118,15 +118,15 @@ closeProjBF <- function(){
     tryCatch(.rqda$.FileofCat[]<-NULL,error=function(e){})
     tryCatch(.rqda$.AttrNamesWidget[] <- NULL,error=function(e){})
     tryCatch(.rqda$.JournalNamesWidget[] <- NULL,error=function(e){})
-    svalue(.rqda$.currentProj) <- "No project is open."
-    names(.rqda$.fnames_rqda) <- "Files"
-    names(.rqda$.codes_rqda) <- "Codes List"
-    names(.rqda$.CodeCatWidget)<-"Code Category"
-    names(.rqda$.CodeofCat)<-"Codes of This Category"
-    names(.rqda$.CasesNamesWidget) <- "Cases"
-    names(.rqda$.FileofCase)<-"Files of This Case"
-    names(.rqda$.FileCatWidget)<-"File Category"
-    names(.rqda$.FileofCat)<-"Files of This Category"
+    svalue(.rqda$.currentProj) <- gettext("No project is open.", domain = "R-RQDA")
+    names(.rqda$.fnames_rqda) <- gettext("Files", domain = "R-RQDA")
+    names(.rqda$.codes_rqda) <- gettext("Codes List", domain = "R-RQDA")
+    names(.rqda$.CodeCatWidget)<-gettext("Code Category", domain = "R-RQDA")
+    names(.rqda$.CodeofCat)<-gettext("Codes of This Category", domain = "R-RQDA")
+    names(.rqda$.CasesNamesWidget) <- gettext("Cases", domain = "R-RQDA")
+    names(.rqda$.FileofCase)<-gettext("Files of This Case", domain = "R-RQDA")
+    names(.rqda$.FileCatWidget)<-gettext("File Category", domain = "R-RQDA")
+    names(.rqda$.FileofCat)<-gettext("Files of This Category", domain = "R-RQDA")
     gtkWidgetSetSensitive(.rqda$.fnames_rqda@widget@widget,FALSE)
     enabled(.rqda$.JournalNamesWidget) <- FALSE
     enabled(.rqda$.codes_rqda) <- FALSE
@@ -188,7 +188,7 @@ closeProjBF <- function(){
 }
 
 CloseProjectButton <- function(container){
-  cloprob <- gbutton("Close Project",container=container,handler=function(h,...){
+  cloprob <- gbutton(gettext("Close Project", domain = "R-RQDA"),container=container,handler=function(h,...){
   closeProjBF()
   closeProject(assignenv=.rqda)
   }
@@ -198,7 +198,7 @@ CloseProjectButton <- function(container){
 }
 
 BackupProjectButton <- function(container){
-  BacProjB <- gbutton("Backup Project",container=container,handler=function(h,...){
+  BacProjB <- gbutton(gettext("Backup Project", domain = "R-RQDA"),container=container,handler=function(h,...){
     backup_proj(con=.rqda$qdacon)
   }
                       )
@@ -207,7 +207,7 @@ BackupProjectButton <- function(container){
 }
 
 
-Proj_MemoButton <- function(label="Porject Memo",container,...){
+Proj_MemoButton <- function(label=gettext("Project Memo", domain = "R-RQDA"),container,...){
   ## Each button a separate function -> more easy to debug, and the main function root_gui is shorter.
   ## The memo in dataset is UTF-8
   ## label of button
@@ -221,7 +221,7 @@ Proj_MemoButton <- function(label="Porject Memo",container,...){
 }
 
 
-CleanProjButton <- function(label="Clean Project",container,...){
+CleanProjButton <- function(label=gettext("Clean Project", domain = "R-RQDA"),container,...){
   CleProB <- gbutton(label, container=container, handler=function(h,...) {
     CleanProject(ask=FALSE)
   }
@@ -230,7 +230,7 @@ CleanProjButton <- function(label="Clean Project",container,...){
   gtkWidgetSetSensitive(button$CleProB@widget@widget,FALSE)
 }
 
-CloseAllCodingsButton <- function(label="Close All Codings",container,...){
+CloseAllCodingsButton <- function(label=gettext("Close All Codings", domain = "R-RQDA"),container,...){
   CloAllCodB <- gbutton(label, container=container, handler=function(h,...) {
     close_AllCodings()
   }
@@ -244,12 +244,12 @@ CloseAllCodingsButton <- function(label="Close All Codings",container,...){
 ## defunct functions
 ####################
 ## ProjectInforButton <- function(container){
-## gbutton("Current Project",container=container,handler=function(h,...){
+## gbutton(gettext("Current Project", domain = "R-RQDA"),container=container,handler=function(h,...){
 ##     if (is_projOpen(envir=.rqda,conName="qdacon")) {
 ##       con <- .rqda$qdacon
 ##       dbname <- dbGetInfo(.rqda$qdacon)$dbname
 ##       ##substr(dbname, nchar(dbname)-15,nchar(dbname))
-##       gmessage(dbname,title="Info about current project.",container=TRUE)
+##       gmessage(dbname,title=gettext("Info about current project.", domain = "R-RQDA"),container=TRUE)
 ##     }
 ##   },
 ##                              action=list(env=.rqda,conName="qdacon")

--- a/R/ProjectFun.R
+++ b/R/ProjectFun.R
@@ -2,7 +2,7 @@ new_proj <- function(path, conName="qdacon",assignenv=.rqda,...){
   ## sucess <- file.create(tmpNamme <- tempfile(pattern = "file", tmpdir = dirname(path)))
   sucess <- (file.access(names=dirname(path),mode=2)==0)
   if (!sucess) {
-    gmessage("No write permission.",icon="error",container=TRUE)
+    gmessage(gettext("No write permission.", domain = "R-RQDA"),icon="error",container=TRUE)
   }
   else{
     ## unlink(tmpNamme)
@@ -10,10 +10,10 @@ new_proj <- function(path, conName="qdacon",assignenv=.rqda,...){
     override <- FALSE
     if (fexist <- file.exists(path)) {
       ## if there exists a file, should ask; and test if have write access to overwrite it.
-      override <- gconfirm("Over write existing project?",icon="warning")
+      override <- gconfirm(gettext("Overwrite existing project?", domain = "R-RQDA"),icon="warning")
       if (file.access(path, 2) != 0 && override) {
         override <- FALSE
-        gmessage("You have no write permission to overwrite it.",con=TRUE,icon="error")
+        gmessage(gettext("You have no write permission to overwrite it.", domain = "R-RQDA"),con=TRUE,icon="error")
       }
     }
     if (!fexist | override ){
@@ -186,9 +186,9 @@ open_proj <- function(path,conName="qdacon",assignenv=.rqda,...){
   } else if (file.access(path, 4) == 0){
       Encoding(path) <- "unknown"
       assign(conName, dbConnect(drv=dbDriver("SQLite"),dbname=path),envir=assignenv)
-      gmessage("You don't have write access to the *.rqda file. You can only read the project.",container=TRUE,icon="warning")
+      gmessage(gettext("You don't have write access to the *.rqda file. You can only read the project.", domain = "R-RQDA"),container=TRUE,icon="warning")
   } else {
-      gmessage("You don't have read access to the *.rqda file. Fail to open.",container=TRUE,icon="error")
+      gmessage(gettext("You don't have read access to the *.rqda file. Fail to open.", domain = "R-RQDA"),container=TRUE,icon="error")
   }
 }
 
@@ -204,7 +204,7 @@ closeProject <- function(conName="qdacon",assignenv=.rqda,...){
         for (i in WidgetList) tryCatch(dispose(get(i,envir=.rqda)),error=function(e){})
         closeProjBF() ## update all widgets
         if (!dbDisconnect(con)) {
-        gmessage("Closing project failed.",icon="waring",container=TRUE)
+        gmessage(gettext("Closing project failed.", domain = "R-RQDA"),icon="waring",container=TRUE)
       }
     }
   } ,error=function(e){})
@@ -221,7 +221,7 @@ is_projOpen <- function(envir=.rqda,conName="qdacon",message=TRUE){
     Open2 <- getFunction("dbIsValid",where=sprintf("package:%s",pkg))(con)
     open <- open + Open2
     } ,error=function(e){})
-  if (!open & message) gmessage("No Project is Open.",icon="warning",container=TRUE)
+  if (!open & message) gmessage(gettext("No Project is Open.", domain = "R-RQDA"),icon="warning",container=TRUE)
   return(open)
 }
 
@@ -232,9 +232,9 @@ backup_proj <- function(con){
   backupname <- sprintf("%s%s.rqda",gsub("rqda$","",dbname),format(Sys.time(), "%H%M%S%d%m%Y"))
   success <- file.copy(from=dbname, to=backupname , overwrite = FALSE)
   if (success) {
-    gmessage("Succeeded!",container=TRUE,icon="info")
+    gmessage(gettext("Succeeded!", domain = "R-RQDA"),container=TRUE,icon="info")
   } else{
-    gmessage("Fail to back up the project.",container=TRUE,icon="error")
+    gmessage(gettext("Fail to back up the project.", domain = "R-RQDA"),container=TRUE,icon="error")
   }
 }
 
@@ -256,7 +256,7 @@ ProjectMemoWidget <- function(){
     .projmemo <- get(".projmemo",.rqda)
     .projmemo2 <- gpanedgroup(horizontal = FALSE, container=.projmemo)
     ## use .projmemo2, so can add a save button to it.
-    proj_memoB <- gbutton("Save memo",container=.projmemo2,handler=function(h,...){
+    proj_memoB <- gbutton(gettext("Save memo", domain = "R-RQDA"),container=.projmemo2,handler=function(h,...){
       ## send the new content of memo back to database
       newcontent <- svalue(W)
       ## Encoding(newcontent) <- "UTF-8"
@@ -298,7 +298,7 @@ ProjectMemoWidget <- function(){
       InRQDA <- dbGetQuery(.rqda$qdacon, "select memo from project where rowid=1")[1, 1]
       if (isTRUE(all.equal(withinWidget,InRQDA))) {
         return(FALSE) } else {
-          val <- gconfirm("The memo has bee change, Close anyway?",container=TRUE)
+          val <- gconfirm(gettext("The memo has bee change. Close anyway?", domain = "R-RQDA"),container=TRUE)
           return(!val)
         }
     }

--- a/R/Setting.R
+++ b/R/Setting.R
@@ -6,71 +6,84 @@ addSettingGUI <- function(container,width=12){
                   children = list(
                     list(type="fieldset",
                          columns = 2,
-                         label = "Settings",
+                         label = gettext("Settings", domain = "R-RQDA"),
                          label.pos = "top",
                          label.font = c(weight="bold"),
                          children = list(
                            list(name = "owner",
-                                label = "Name of Coder",
+                                label = gettext("Name of Coder", domain = "R-RQDA"),
                                 type = "gedit",width=width,
                                 text = .rqda$owner
                                 ),
                            list(name = "encoding",
-                                label = "File Encoding",
+                                label = gettext("File Encoding", domain = "R-RQDA"),
                                 type = "gedit",width=width,
                                 text = .rqda$encoding
                                 ),
                            list(name = "fore.col",
-                                label = "Color for Coding",
+                                label = gettext("Color for Coding", domain = "R-RQDA"),
                                 ## type = "gedit",width=width,
                                 ## text = .rqda$fore.col
                                 type = "gcombobox",
                                 items=c(.rqda$fore.col,colorsList)
                                 ),
                            list(name = "back.col",
-                                label = "Color for Case",
+                                label = gettext("Color for Case", domain = "R-RQDA"),
                                 ## type = "gedit",width=width,
                                 ## text = .rqda$back.col
                                 type = "gcombobox",
                                 items=c(.rqda$back.col,colorsList)
                                 ),
                            list(name = "codingTable",
-                                label = "Current coding table",
+                                label = gettext("Current coding table", domain = "R-RQDA"),
                                 type = "gcombobox",
                                 items=c(.rqda$codingTable,"coding2")
                                 ),
                            list(name = "BOM",
-                                label = "Byte Order Mark",
+                                label = gettext("Byte Order Mark", domain = "R-RQDA"),
                                 type = "gcombobox",## width=width,
                                 items = c(FALSE, TRUE)
                                 ),
                            list(name = "SFP",
-                                label = "Show File Property",
+                                label = gettext("Show File Property", domain = "R-RQDA"),
                                 type = "gcombobox",## width=width,
                                 items = c(FALSE, TRUE)
                                 ),
                            list(name = "TOR",
                                 type="gcombobox",
-                                label = "Type of Retrieval",
-                                items = c(.rqda$TOR, "case", "filecategory","both")
+                                label = gettext("Type of Retrieval", domain = "R-RQDA"),
+                                items = c(gettext("unconditional", domain = "R-RQDA"),
+                                          gettext("case", domain = "R-RQDA"),
+                                          gettext("filecategory", domain = "R-RQDA"),
+                                          gettext("both", domain = "R-RQDA"))
                                 )
                            )
                          )
                     )
                   )
 
-  ans <- glabel("Click to set font",container = container,handler=function(h,...) setFont(default=.rqda$font))## set font for widget
-  gtkWidgetSetTooltipText(getToolkitWidget(ans),"Set fonts for memo widgets.")
+  ans <- glabel(gettext("Click to set font", domain = "R-RQDA"),container = container,handler=function(h,...) setFont(default=.rqda$font))## set font for widget
+  gtkWidgetSetTooltipText(getToolkitWidget(ans), gettext("Set fonts for memo widgets.", domain = "R-RQDA"))
 
   SettingFL <- gformlayout(Setting, container = container, expand=TRUE)
 
   ButtonContainer <- ggroup(container = container) ##, width=100) ## not necessary to set width here
   addSpring(ButtonContainer)
-  resetButton <- gbutton("Default", container = ButtonContainer)
-  okButton <- gbutton("OK", container = ButtonContainer)
+  resetButton <- gbutton(gettext("Default", domain = "R-RQDA"), container = ButtonContainer)
+  okButton <- gbutton(gettext("OK", domain = "R-RQDA"), container = ButtonContainer)
 
   addHandlerChanged(okButton, function(h,...) {
     out <- svalue(SettingFL)
+    ## Untranslate Type Of Retrieve:
+    if(out["TOR"] == gettext("unconditional", domain = "R-RQDA"))
+        out["TOR"] <- "unconditional"
+    else if(out["TOR"] == gettext("case", domain = "R-RQDA"))
+        out["TOR"] <- "case"
+    else if(out["TOR"] == gettext("filecategory", domain = "R-RQDA"))
+        out["TOR"] <- "filecategory"
+    else if(out["TOR"] == gettext("both", domain = "R-RQDA"))
+        out["TOR"] <- "both"
+
     tryCatch(ClearMark(.rqda$.root_edit,0,nchar(svalue(.rqda$.openfile_gui)),TRUE,TRUE),error=function(e){})
     for (i in names(out)) assign(i,out[[i]],envir=.rqda)
   })
@@ -84,7 +97,7 @@ addSettingGUI <- function(container,width=12){
     tryCatch(svalue(SettingFL[]$back.col) <- "gold",error=function(e){})
     tryCatch(svalue(SettingFL[]$fore.col) <- "blue",error=function(e){})
     tryCatch(svalue(SettingFL[]$codingTable) <- "coding",error=function(e){})
-    tryCatch(svalue(SettingFL[]$TOR) <- "unconditional",error=function(e){})
+    tryCatch(svalue(SettingFL[]$TOR) <- gettext("unconditional", domain = "R-RQDA"),error=function(e){})
     assign("BOM",FALSE,envir=.rqda)
     assign("SFP",FALSE,envir=.rqda)
     assign("encoding","unknown",envir=.rqda)
@@ -92,7 +105,7 @@ addSettingGUI <- function(container,width=12){
     assign("back.col","gold",envir=.rqda)
     assign("fore.col","blue",envir=.rqda)
     assign("codingTable","coding",envir=.rqda)
-    assign("TOR","unconditional",envir=.rqda)
+    assign("TOR", "unconditional",envir=.rqda)
     assign("font","Sans 11",envir=.rqda)
   })}
 

--- a/R/annotations.R
+++ b/R/annotations.R
@@ -2,7 +2,7 @@ getAnnos <- function(){
     anno <- RQDAQuery("select annotation.fid, annotation, annotation.date, source.name from annotation join source where annotation.fid==source.id and annotation != '' ")
     Encoding(anno$annotation) <- Encoding(anno$name) <- "UTF-8"
     attr(anno,"field.name") <- "annotation"
-    attr(anno, "descr") <- sprintf("%i %s", nrow(anno), ngettext(nrow(anno), "Annotaiton", "Annotations"))
+    attr(anno, "descr") <- sprintf("%i %s", nrow(anno), ngettext(nrow(anno), "Annotation", "Annotations", domain = "R-RQDA"))
     class(anno) <- c("annotations", "Info4Widget", "data.frame")
     anno
 }

--- a/R/colorSelector.R
+++ b/R/colorSelector.R
@@ -2,10 +2,10 @@ setColor <- function(currentColor="gold"){
   currentColor <- gdkColorParse(currentColor)$color
   colorDA <- gtkDrawingAreaNew()
   colorDA$modifyBg("normal", currentColor)
-  g <-glayout(container=gwindow(width=50,height=20,parent=getOption("widgetCoordinate")),homogeneous=TRUE,title="Change color.")
+  g <-glayout(container=gwindow(width=50,height=20,parent=getOption("widgetCoordinate")),homogeneous=TRUE,title=gettext("Change color.", domain = "R-RQDA"))
   g[1,1:3] <- colorDA
-  g[2,1] <- gbutton("Select Color",handler=function(h,...){
-  dialog <- gtkColorSelectionDialogNew("Changing color", show=T)
+  g[2,1] <- gbutton(gettext("Select Color", domain = "R-RQDA"),handler=function(h,...){
+  dialog <- gtkColorSelectionDialogNew(gettext("Changing color", domain = "R-RQDA"), show=T)
   colorsel <- dialog[["colorsel"]]
   colorsel$setPreviousColor(currentColor)
   colorsel$setCurrentColor(currentColor)
@@ -19,8 +19,8 @@ setColor <- function(currentColor="gold"){
     }
   dialog$destroy()
   })
-  g[2,2] <- gbutton("OK",handler=function(h,...) {
+  g[2,2] <- gbutton(gettext("OK", domain = "R-RQDA"),handler=function(h,...) {
    dispose(g)})
-  g[2,3] <- gbutton("Cancle",handler=function(h,...) {
+  g[2,3] <- gbutton(gettext("Cancel", domain = "R-RQDA"),handler=function(h,...) {
    dispose(g)})
 }

--- a/R/deletion.R
+++ b/R/deletion.R
@@ -33,7 +33,7 @@ pdelete <- function(type=c("file","code","case","codecategory","filecategory","c
   codingFun <- function(ask) {
     ## erase deleted coding by unmark button
     if (ask) {
-      del <- gconfirm("Are you sure to clean the coding table?",icon="question")
+      del <- gconfirm(gettext("Are you sure to clean the coding table?", domain = "R-RQDA"),icon="question")
     } else del <- TRUE
     if (del) {
       dbGetQuery(.rqda$qdacon,"delete from coding where status = -1")

--- a/R/getCodings.R
+++ b/R/getCodings.R
@@ -35,12 +35,20 @@ getCodingsFromFiles <- function(Fid, order=c("fname","ftime","ctime"), codingTab
                     ftime="order by freecode.name, source.id, selfirst, selend ASC",
                     ctime="")
     retrieval <- RQDAQuery(sprintf("select cid, freecode.name as code, fid, selfirst, selend, seltext, %s.rowid, source.name,source.id from %s,source, freecode where %s.status=1 and source.id=fid and freecode.id=%s.cid and fid in (%s) %s", codingTable, codingTable, codingTable, codingTable, paste(Fid,collapse=","), order))
-    if (nrow(retrieval)==0) gmessage("No Coding associated with the selected code.",container=TRUE) else {
+    if (nrow(retrieval)==0) gmessage(gettext("No Coding associated with the selected code.", domain = "R-RQDA"),container=TRUE) else {
         fid <- unique(retrieval$fid)
         Nfiles <- length(fid)
         retrieval$fname <-""
         Ncodings <- nrow(retrieval)
-        title <- sprintf(ngettext(Ncodings,"%i Retrieved coding from %i %s", "%i Retrieved codings from %i %s"),Ncodings, Nfiles, ngettext(Nfiles,"file","files"))
+        if(Ncodings == 1){
+            title <- sprintf(ngettext(Nfiles,
+                                      "1 retrieved coding from %i file",
+                                      "1 retrieved coding from %i files", domain = "R-RQDA"), Nfiles)
+        } else {
+            title <- sprintf(ngettext(Nfiles,
+                                      "%i retrieved codings from %i file",
+                                      "%i retrieved codings from %i files", domain = "R-RQDA"), Ncodings, Nfiles)
+        }
         wnh <- size(.rqda$.root_rqdagui) ## size of the main window
         .gw <- gwindow(title=title, parent=c(wnh[1]+10,2),
                        width = min(c(gdkScreenWidth()- wnh[1]-20,getOption("widgetSize")[1])),
@@ -94,7 +102,7 @@ getCodingsFromFiles <- function(Fid, order=c("fname","ftime","ctime"), codingTab
             anchorcreated <- buffer$createChildAnchor(iter)
             iter$BackwardChar()
             anchor <- iter$getChildAnchor()
-            lab <- gtkLabelNew("Back")
+            lab <- gtkLabelNew(gettext("Back", domain = "R-RQDA"))
             widget <- gtkEventBoxNew()
             widget$Add(lab)
             gSignalConnect(widget, "button-press-event",

--- a/R/merger.R
+++ b/R/merger.R
@@ -2,7 +2,7 @@ mergeCodes <- function(cid1,cid2){ ## cid1 and cid2 are two code IDs.
   mergeHelperFUN <- function(From,Exist){ ## from and exist are data frame of codings.
     if (nrow(Exist)==0){## just write to the new code if there is no coding related to that code.
       success <- dbWriteTable(.rqda$qdacon,"coding",From,row.name=FALSE,append=TRUE)
-      if (!success) gmessage("Fail to write to database.")
+      if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
     } else {
       Relations <- apply(Exist[c("selfirst","selend")],1,FUN=function(x) relation(x,c(From$selfirst,From$selend)))
       ## because apply convert data to an array, and Exist containts character -> x is charater rather than numeric
@@ -18,7 +18,7 @@ mergeCodes <- function(cid1,cid2){ ## cid1 and cid2 are two code IDs.
             dis <- sapply(Relations,function(x) x$Distance)
             if (all(dis>0)) {
                 success <- dbWriteTable(.rqda$qdacon,"coding",From,row.name=FALSE,append=TRUE)
-                if (!success) gmessage("Fail to write to database.")
+                if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
             } else {
                 idx0 <- which(dis==0)
                 index3 <- unlist(c(From[,c("selfirst","selend")], Exist[idx0,c("selfirst","selend")]))
@@ -50,7 +50,7 @@ mergeCodes <- function(cid1,cid2){ ## cid1 and cid2 are two code IDs.
                               selfirst=Sel[1],selend=Sel[2],status=1,
                               owner=.rqda$owner,date=date(),memo=memo) ## The new coding to table.
             success <- dbWriteTable(.rqda$qdacon,"coding",DAT,row.name=FALSE,append=TRUE)
-            if (!success) gmessage("Fail to write to database.")
+            if (!success) gmessage(gettext("Fail to write to database.", domain = "R-RQDA"))
           }
         }
       }
@@ -59,7 +59,7 @@ mergeCodes <- function(cid1,cid2){ ## cid1 and cid2 are two code IDs.
 
   Coding1 <-  dbGetQuery(.rqda$qdacon,sprintf("select * from coding where cid=%i and status=1",cid1))
   Coding2 <-  dbGetQuery(.rqda$qdacon,sprintf("select * from coding where cid=%i and status=1",cid2))
-  if (any(c(nrow(Coding1),nrow(Coding2))==0)) stop("One code has empty coding.")
+  if (any(c(nrow(Coding1),nrow(Coding2))==0)) stop("One code has empty coding.", domain = "R-RQDA")
   if (nrow(Coding1) >= nrow(Coding2)) {
     FromDat <- Coding2
     ToDat <- Coding1

--- a/R/parseRelationNet.R
+++ b/R/parseRelationNet.R
@@ -4,7 +4,7 @@
      mapStr <- mapStr[!grepl("^#", mapStr)] ## strip comment lines
      mapStr <- mapStr[map!=""] # throw the empty lines
      nrelations <- sapply(gregexpr("->",mapStr), length)
-     if (!all(nrelations==1))  stop("Each line represents one relation only")
+     if (!all(nrelations==1))  stop("Each line represents one relation only", domain = "R-RQDA")
      ix1 <- regexpr("\\[",mapStr)
      ix2 <- regexpr("\\]",mapStr)
      relation <- substr(mapStr,ix1,ix2)

--- a/R/pdf.R
+++ b/R/pdf.R
@@ -13,7 +13,7 @@ importPDFHL <- function(file, type=c("Highlight"), engine="rjpod"){
         if (nrow(RQDAQuery(sprintf("select name from source where name='%s'", fileName)))==0) {
             write <- TRUE
         } else {
-            gmessage("A file withe the same name exists in the database!")
+            gmessage(gettext("A file with the same name exists in the database!", domain = "R-RQDA"))
         }
     }
     if (write ) {

--- a/R/relation.R
+++ b/R/relation.R
@@ -6,10 +6,10 @@ relation <- function(index1,index2){
   ## WhichMax: which argument containts max(c(index1,index2))
   ## Distance: The distance between to index when Relation is proximity
   ## the index of the overlap of index1 and index2.
-  if ( !is.vector(index1) || !is.vector(index1) ) stop("index1 and index2 must be vector.")
+  if ( !is.vector(index1) || !is.vector(index1) ) stop("index1 and index2 must be vector.", domain = "R-RQDA")
   index1 <- as.numeric(index1)
   index2 <- as.numeric(index2)
-  if (any(is.na(c(index1,index2)))) stop("index1 or index2 should not have any NA.")
+  if (any(is.na(c(index1,index2)))) stop("index1 or index2 should not have any NA.", domain = "R-RQDA")
   names(index1) <- names(index2) <- NULL
   if (length(index1)==2 || length(index1)==2){
     Max <- max(c(index1,index2))
@@ -90,7 +90,7 @@ CrossTwo <- function(cid1, cid2,data,relation=c("overlap","inclusion","exact","p
 crossCodes <- CrossCode <- function(relation=c("overlap","inclusion","exact","proximity"),codeList=NULL,data=GetCodingTable(),print=TRUE,...){
 ## codeList is character vector of codes.
   if (nrow(data)==0) {
-    stop("No coding in this project.")
+    stop("No coding in this project.", domain = "R-RQDA")
   } else{
     Cid_Name <- unique(data[,c("cid","codename")])
     if (is.null(codeList)) {
@@ -98,10 +98,10 @@ crossCodes <- CrossCode <- function(relation=c("overlap","inclusion","exact","pr
     } else {
         nList <- length(codeList)
         codeList <- intersect(Cid_Name$codename,codeList)
-        if (nList > length(codeList)) cat("Codes without codings dropped.\n")
+        if (nList > length(codeList)) cat(gettext("Codes without codings dropped.\n", domain = "R-RQDA"))
     }
     if (length(codeList)<2) {
-      stop("The codeList should be a vector of length 2 or abvoe.")
+      stop("The codeList should be a vector of length 2 or greater", domain = "R-RQDA")
     } else {
       cidList <- Cid_Name$cid[match(codeList, Cid_Name$codename)]
       relation <- match.arg(relation)

--- a/R/retrieval_by_code.R
+++ b/R/retrieval_by_code.R
@@ -20,17 +20,24 @@ retrieval_by_code <- function (Fid = NULL, order = c("fname", "ftime", "ctime"),
                 paste(Fid, collapse = ","), order))
         }
         if (nrow(retrieval) == 0) 
-            gmessage("No Coding associated with the selected code.", 
+            gmessage(gettext("No Coding associated with the selected code.", domain = "R-RQDA"), 
                 container = TRUE)
         else {
             fid <- unique(retrieval$fid)
             retrieval$fname <- ""
             Nfiles <- length(fid)
             Ncodings <- nrow(retrieval)
-            title <- sprintf(ngettext(Ncodings, "%i Retrieved coding: \"%s\" from %s %s", 
-                "%i Retrieved codings: \"%s\" from %s %s"), Ncodings, 
-                currentCode2, Nfiles, ngettext(Nfiles, "file", 
-                  "files"))
+            if(Ncodings == 1){
+                title <- sprintf(ngettext(Nfiles,
+                                          "1 retrieved coding: \"%s\" from %i file", 
+                                          "1 retrieved coding: \"%s\" from %i files", domain = "R-RQDA"),
+                                 currentCode2, Nfiles)
+            } else {
+                title <- sprintf(ngettext(Nfiles,
+                                          "%i retrieved codings: \"%s\" from %i file", 
+                                          "%i retrieved codings: \"%s\" from %i files", domain = "R-RQDA"),
+                                 Ncodings, currentCode2, Nfiles)
+            }
             tryCatch(eval(parse(text = sprintf("dispose(.rqda$.codingsOf%s)", 
                 currentCid))), error = function(e) {
             })
@@ -93,7 +100,7 @@ retrieval_by_code <- function (Fid = NULL, order = c("fname", "ftime", "ctime"),
                 anchorcreated <- buffer$createChildAnchor(iter)
                 iter$BackwardChar()
                 anchor <- iter$getChildAnchor()
-                lab <- gtkLabelNew("Back")
+                lab <- gtkLabelNew(gettext("Back", domain = "R-RQDA"))
                 widget <- gtkEventBoxNew()
                 widget$Add(lab)
                 gSignalConnect(widget, "button-press-event", 

--- a/R/root_gui.R
+++ b/R/root_gui.R
@@ -7,7 +7,7 @@ if (isTRUE(.rqda$isLaunched)) {
  message("RQDA has been launched.")
  } else
 {
-  ".root_rqdagui" <- gwindow(title = "RQDA: Qualitative Data Analysis",parent=c(2,2),
+  ".root_rqdagui" <- gwindow(title = gettext("RQDA: Qualitative Data Analysis", domain = "R-RQDA"),parent=c(2,2),
                              width=300,height=(gdkScreenHeight()-65),
                              visible=FALSE,handler=function(h,...){
                                closeProject(assignenv=.rqda)
@@ -21,124 +21,124 @@ if (isTRUE(.rqda$isLaunched)) {
 
 ########################### GUI FOR PROJECT
 ###########################
-  ".proj_gui" <- ggroup(container=.nb_rqdagui,horizontal=FALSE,label="Project\n")
+  ".proj_gui" <- ggroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Project\n", domain = "R-RQDA"))
   NewProjectButton(container=.proj_gui)
   OpenProjectButton(container=.proj_gui)
   CloseProjectButton(container=.proj_gui)
-  Proj_MemoButton(label = "Project Memo", container = .proj_gui)
+  Proj_MemoButton(label = gettext("Project Memo", domain = "R-RQDA"), container = .proj_gui)
   ## project memo button
   BackupProjectButton(container=.proj_gui)
-  saveAsButt(label="Save Project As", container=.proj_gui)
+  saveAsButt(label=gettext("Save Project As", domain = "R-RQDA"), container=.proj_gui)
   CleanProjButton(container=.proj_gui)
   CloseAllCodingsButton(container=.proj_gui)
-  ##gbutton("About",container=.proj_gui, handler=function(h,...) {browseURL("http://rqda.r-forge.r-project.org/")})
+  ##gbutton(gettext("About", domain = "R-RQDA"),container=.proj_gui, handler=function(h,...) {browseURL("http://rqda.r-forge.r-project.org/")})
 
   gseparator(container=.proj_gui)
-  glabel("Path of current project:",container=.proj_gui)
-  ".currentProj" <- glabel("No project is open.",container=.proj_gui)
+  glabel(gettext("Path of current project:", domain = "R-RQDA"),container=.proj_gui)
+  ".currentProj" <- glabel(gettext("No project is open.", domain = "R-RQDA"),container=.proj_gui)
 
   gseparator(container=.proj_gui)
-  glabel("Author: <ronggui.huang@gmail.com>",container=.proj_gui)
-  glabel("Help: click to join rqda-help mailing list",
+  glabel(gettext("Author: <ronggui.huang@gmail.com>", domain = "R-RQDA"),container=.proj_gui)
+  glabel(gettext("Help: click to join rqda-help mailing list", domain = "R-RQDA"),
          container=.proj_gui, handler=function(h,...){
              browseURL("https://lists.r-forge.r-project.org/cgi-bin/mailman/listinfo/rqda-help")
          })
   gseparator(container=.proj_gui)
-  glabel("License: BSD",
+  glabel(gettext("License: BSD", domain = "R-RQDA"),
          container=.proj_gui, handler=function(h,...){
            gtext(paste(readLines((system.file("License",package="RQDA")), warn=FALSE) , collapse="\n"),
                  container=gwindow(title="License"))
          })
   glabel(
-         paste("Version:", packageDescription("RQDA")$Version, " Year:", substr(packageDescription("RQDA")$Date,1,4)),
+         paste(gettext("Version:", domain = "R-RQDA"), packageDescription("RQDA")$Version, gettext(" Year:", domain = "R-RQDA"), substr(packageDescription("RQDA")$Date,1,4)),
          container=.proj_gui, handler=function(h,...){
-             gtext(format(citation("RQDA"), "textVersion"), container=gwindow(title="Please cite this package."))
+             gtext(format(citation("RQDA"), "textVersion"), container=gwindow(title=gettext("Please cite this package.", domain = "R-RQDA")))
          })
-  glabel("About",
+  glabel(gettext("About", domain = "R-RQDA"),
          container=.proj_gui, handler=function(h,...){
              browseURL("http://rqda.r-forge.r-project.org/")
          })
 
 ########################### GUI for FILES
 ###########################
-  ".files_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="Files\n")
+  ".files_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Files\n", domain = "R-RQDA"))
   ".files_button" <- ggroup(container=.files_pan,horizontal=TRUE)
   ##".fnames_rqda"<-gtable("Click Here to see the File list.",container=.files_pan,multiple=TRUE)
   ##.fnames_rqda[] <-NULL # get around of the text argument.
   ".fnames_rqda" <- gtable(character(0),container=.files_pan,multiple=TRUE)
-  names(.fnames_rqda) <- "Files"
-  ImportFileButton("Import",container=.files_button)
-  NewFileButton("New",container=.files_button)
-  DeleteFileButton("Delete",container=.files_button)
-  ViewFileButton("Open",container=.files_button)
-  File_MemoButton(label="Memo", container=.files_button,FileWidget=.fnames_rqda)
+  names(.fnames_rqda) <- gettext("Files", domain = "R-RQDA")
+  ImportFileButton(gettext("Import", domain = "R-RQDA"),container=.files_button)
+  NewFileButton(gettext("New", domain = "R-RQDA"),container=.files_button)
+  DeleteFileButton(gettext("Delete", domain = "R-RQDA"),container=.files_button)
+  ViewFileButton(gettext("Open", domain = "R-RQDA"),container=.files_button)
+  File_MemoButton(label=gettext("Memo", domain = "R-RQDA"), container=.files_button,FileWidget=.fnames_rqda)
   ## memo button of selected file. The code of File_Memo buttion has been moved into memo.R
-  File_RenameButton(label="Rename", container=.files_button,FileWidget=.fnames_rqda)
+  File_RenameButton(label=gettext("Rename", domain = "R-RQDA"), container=.files_button,FileWidget=.fnames_rqda)
   ## rename a selected file.
-  FileAttribute_Button(label="Attribute", container=.files_button,FileWidget=.fnames_rqda)
+  FileAttribute_Button(label=gettext("Attribute", domain = "R-RQDA"), container=.files_button,FileWidget=.fnames_rqda)
 
 ########################### GUI for CODES
 ###########################
-  ".codes_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="Codes\n")
+  ".codes_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Codes\n", domain = "R-RQDA"))
   ".codes_button" <- glayout(container=.codes_pan)
   ".codes_rqda" <- gtable(character(0),container=.codes_pan)
-  names(.codes_rqda) <- "Codes List"
+  names(.codes_rqda) <- gettext("Codes List", domain = "R-RQDA")
   .codes_button[1,1]<- AddCodeButton()
   .codes_button[1,2]<- DeleteCodeButton()
-  .codes_button[1,3] <- FreeCode_RenameButton(label="Rename",CodeNamesWidget=.codes_rqda)
-  .codes_button[1,4] <- CodeMemoButton(label="Memo")
-  .codes_button[2,1] <-  AnnotationButton("Anno")
+  .codes_button[1,3] <- FreeCode_RenameButton(label=gettext("Rename", domain = "R-RQDA"),CodeNamesWidget=.codes_rqda)
+  .codes_button[1,4] <- CodeMemoButton(label=gettext("Memo", domain = "R-RQDA"))
+  .codes_button[2,1] <-  AnnotationButton(gettext("Anno", domain = "R-RQDA"))
   ## .codes_button[2,1]<- CodingMemoButton(label="C2Memo")
-  .codes_button[2,2]<- RetrievalButton("Coding")
+  .codes_button[2,2]<- RetrievalButton(gettext("Coding", domain = "R-RQDA"))
   .codes_button[2,3]<- Unmark_Button(name="UnMarB1")
   .codes_button[2,4]<- Mark_Button(name="MarCodB1")
 
 
 ######################### GUI  for code categories
 #########################
-  ".codecat_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="Code\nCategories")
+  ".codecat_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Code\nCategories", domain = "R-RQDA"))
   ".codecat_buttons" <- glayout(container=.codecat_pan)
   ".Ccat_PW" <- ggroup(container=.codecat_pan,horizontal = FALSE)## parent Widget of C-cat
   ".CodeCatWidget" <- gtable(character(0),container=.Ccat_PW,expand=TRUE,multiple=TRUE)
-  names(.CodeCatWidget)<-"Code Category"
-  ".CodeofCat" <- gtable("Please click Update",container=.Ccat_PW,expand=TRUE,multiple=TRUE)
-  .CodeofCat[] <- NULL;names(.CodeofCat)<-"Codes of This Category"
-  .codecat_buttons[1,1] <- AddCodeCatButton("Add")
-  .codecat_buttons[1,2] <- DeleteCodeCatButton("Delete") ## should take care of treecode table
-  .codecat_buttons[1,3] <- CodeCat_RenameButton("Rename")
-  .codecat_buttons[2,1] <- CodeCatAddToButton("Add To")
-  .codecat_buttons[2,2] <- CodeCatDropFromButton("Drop From")
+  names(.CodeCatWidget)<- gettext("Code Category", domain = "R-RQDA")
+  ".CodeofCat" <- gtable(gettext("Please click Update", domain = "R-RQDA"),container=.Ccat_PW,expand=TRUE,multiple=TRUE)
+  .CodeofCat[] <- NULL;names(.CodeofCat)<-gettext("Codes of This Category", domain = "R-RQDA")
+  .codecat_buttons[1,1] <- AddCodeCatButton(gettext("Add", domain = "R-RQDA"))
+  .codecat_buttons[1,2] <- DeleteCodeCatButton(gettext("Delete", domain = "R-RQDA")) ## should take care of treecode table
+  .codecat_buttons[1,3] <- CodeCat_RenameButton(gettext("Rename", domain = "R-RQDA"))
+  .codecat_buttons[2,1] <- CodeCatAddToButton(gettext("Add To", domain = "R-RQDA"))
+  .codecat_buttons[2,2] <- CodeCatDropFromButton(gettext("Drop From", domain = "R-RQDA"))
   .codecat_buttons[1,4] <- CodeCatMemoButton()
-  .codecat_buttons[2,3] <- Unmark_Button(label="UnMark", codeListWidget=.rqda$.CodeofCat,name="UnMarB2")
-  .codecat_buttons[2,4] <- Mark_Button(label="Mark", codeListWidget=".CodeofCat",name="MarCodB2")
+  .codecat_buttons[2,3] <- Unmark_Button(label=gettext("UnMark", domain = "R-RQDA"), codeListWidget=.rqda$.CodeofCat,name="UnMarB2")
+  .codecat_buttons[2,4] <- Mark_Button(label=gettext("Mark", domain = "R-RQDA"), codeListWidget=".CodeofCat",name="MarCodB2")
 
 
 ######################### GUI  for cases
 #########################
-  ".case_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="Cases\n")
+  ".case_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Cases\n", domain = "R-RQDA"))
   ".case_buttons" <- glayout(container=.case_pan)
   ".case_PW" <- ggroup(container=.case_pan,horizontal = FALSE)
   ".CasesNamesWidget" <- gtable(character(0),container=.case_PW,expand=TRUE,multiple=TRUE)
-  names(.CasesNamesWidget) <- "Cases"
+  names(.CasesNamesWidget) <- gettext("Cases", domain = "R-RQDA")
   ".FileofCase" <- gtable(character(0),container=.case_PW,expand=TRUE,multiple=TRUE)
-  names(.FileofCase)<-"Files of This Case"
+  names(.FileofCase)<-gettext("Files of This Case", domain = "R-RQDA")
   .case_buttons[1,1] <- AddCaseButton()
   .case_buttons[1,2] <- DeleteCaseButton()
   .case_buttons[1,3] <- Case_RenameButton()
   ##.case_buttons[1,4] <- CaseMemoButton()
-  .case_buttons[1,4] <- CaseUnMark_Button("Unlink")
-  .case_buttons[1,5] <- CaseMark_Button(" Link ")
-  .case_buttons[2,1] <- CaseAttribute_Button("Attribute")
-  .case_buttons[2,2] <- prof_mat_Button("Profile")
+  .case_buttons[1,4] <- CaseUnMark_Button(gettext("Unlink", domain = "R-RQDA"))
+  .case_buttons[1,5] <- CaseMark_Button(gettext(" Link ", domain = "R-RQDA"))
+  .case_buttons[2,1] <- CaseAttribute_Button(gettext("Attribute", domain = "R-RQDA"))
+  .case_buttons[2,2] <- prof_mat_Button(gettext("Profile", domain = "R-RQDA"))
   ##.case_buttons[2,3] <- AddWebSearchButton("WebSearch") # use popup menu instead
 
 ########################### GUI for Attributes
 ###########################
-  ".attr_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="Attributes\n")
+  ".attr_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Attributes\n", domain = "R-RQDA"))
   ".attr_buttons" <- glayout(container=.attr_pan)
   ".attr_PW" <- ggroup(container=.attr_pan,horizontal = FALSE)
   ".AttrNamesWidget" <- gtable(character(0),container=.attr_PW,expand=TRUE,multiple=TRUE)
-  names(.AttrNamesWidget) <- "Attributes"
+  names(.AttrNamesWidget) <- gettext("Attributes", domain = "R-RQDA")
   .attr_buttons[1,1] <- AddAttrButton()
   .attr_buttons[1,2] <- DeleteAttrButton()
   .attr_buttons[1,3] <- RenameAttrButton()
@@ -148,35 +148,35 @@ if (isTRUE(.rqda$isLaunched)) {
 
 ######################### GUI  for File categories
 #########################
-  ".filecat_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="File\nCategories")
+  ".filecat_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("File\nCategories", domain = "R-RQDA"))
   ".filecat_buttons" <- glayout(container=.filecat_pan)
   ".Fcat_PW" <- ggroup(container=.filecat_pan,horizontal = FALSE)## parent Widget of F-cat
   ".FileCatWidget" <- gtable(character(0),container=.Fcat_PW,expand=TRUE,multiple=TRUE)
-  names(.FileCatWidget)<-"File Category"
+  names(.FileCatWidget) <- gettext("File Category", domain = "R-RQDA")
   ".FileofCat" <- gtable(character(0),container=.Fcat_PW,expand=TRUE,multiple=TRUE)
-  names(.FileofCat)<-"Files of This Category"
-  .filecat_buttons[1,1] <- AddFileCatButton("Add")
-  .filecat_buttons[1,2] <- DeleteFileCatButton("Delete") ## should take care of treecode table
-  .filecat_buttons[1,3] <- FileCat_RenameButton("Rename")
+  names(.FileofCat) <- gettext("Files of This Category", domain = "R-RQDA")
+  .filecat_buttons[1,1] <- AddFileCatButton(gettext("Add", domain = "R-RQDA"))
+  .filecat_buttons[1,2] <- DeleteFileCatButton(gettext("Delete", domain = "R-RQDA")) ## should take care of treecode table
+  .filecat_buttons[1,3] <- FileCat_RenameButton(gettext("Rename", domain = "R-RQDA"))
   .filecat_buttons[2,3] <- FileCatMemoButton()
-  .filecat_buttons[2,1] <- FileCatAddToButton("Add To")
-  .filecat_buttons[2,2] <- FileCatDropFromButton("Drop From")
+  .filecat_buttons[2,1] <- FileCatAddToButton(gettext("Add To", domain = "R-RQDA"))
+  .filecat_buttons[2,2] <- FileCatDropFromButton(gettext("Drop From", domain = "R-RQDA"))
 
 ########################### GUI for Search
 ###########################
 ##   ".fsearch_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="F-Search")
-##  ".fsearch_rqda" <- glabel("Use SearchFiles function to search files.\nSee ?SearchFiles for more.",container=.fsearch_pan)
-##  ".fsearch_rqda" <- gtable("Click Here to see the File list.",container=.fsearch_pan,multiple=TRUE,expand=TRUE)
+##  ".fsearch_rqda" <- glabel(gettext("Use SearchFiles function to search files.\nSee ?SearchFiles for more.", domain = "R-RQDA"),container=.fsearch_pan)
+##  ".fsearch_rqda" <- gtable(gettext("Click Here to see the File list.", domain = "R-RQDA"),container=.fsearch_pan,multiple=TRUE,expand=TRUE)
 ##  .fsearch_rqda[] <-NULL # get around of the text argument.
 ##  names(.fsearch_rqda) <- "Files Search"
 
 ########################### GUI for Journal
 ###########################
-  ".journal_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label="Journals\n")
+  ".journal_pan" <- gpanedgroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Journals\n", domain = "R-RQDA"))
   ".journal_buttons" <- glayout(container=.journal_pan)
   ".journal_PW" <- ggroup(container=.journal_pan,horizontal = FALSE)
   ".JournalNamesWidget" <- gtable(character(0),container=.journal_PW,expand=TRUE,multiple=FALSE)
-  names(.JournalNamesWidget) <- "Journals"
+  names(.JournalNamesWidget) <- gettext("Journals", domain = "R-RQDA")
   .journal_buttons[1,1] <- AddJournalButton()
   .journal_buttons[1,2] <- DeleteJournalButton()
   .journal_buttons[1,3] <-  OpenJournalButton()
@@ -184,7 +184,7 @@ if (isTRUE(.rqda$isLaunched)) {
 
 ######################### GUI  for settings
 #########################
-  ".settings_gui" <- ggroup(container=.nb_rqdagui,horizontal=FALSE,label="Settings\n")
+  ".settings_gui" <- ggroup(container=.nb_rqdagui,horizontal=FALSE,label=gettext("Settings\n", domain = "R-RQDA"))
   addSettingGUI(container=.settings_gui)
 
 ######################### Put them together
@@ -251,7 +251,7 @@ AddHandler <- function(){
   addHandlerUnrealize(.rqda$.root_rqdagui, handler = function(h,...) {
     ## handler for Root
     ## make sure is the project should be closed by issuing a confirm window.
-    val <- gconfirm("Really EXIT?\n\nYou can use RQDA() to start this program again.", parent=h$obj)
+    val <- gconfirm(gettext("Really EXIT?\n\nYou can use RQDA() to start this program again.", domain = "R-RQDA"), parent=h$obj)
     if(as.logical(val)) {
       assign("isLaunched",FALSE,envir=.rqda)
       return(FALSE) # destroy
@@ -266,7 +266,7 @@ AddHandler <- function(){
     if (isTRUE(.rqda$SFP)) ShowFileProperty(focus=FALSE)
     Fid <- GetFileId(,"select")
     if (!is.null(Fid) && length(Fid)==1) {
-      names(.rqda$.fnames_rqda) <- sprintf("Selected File id is %s",Fid)
+      names(.rqda$.fnames_rqda) <- sprintf(gettext("Selected File id is %s", domain = "R-RQDA"),Fid)
       gtkWidgetSetSensitive(button$DelFilB@widget@widget,TRUE)
       gtkWidgetSetSensitive(button$VieFilB@widget@widget,TRUE)
       gtkWidgetSetSensitive(button$FilMemB@widget@widget,TRUE)
@@ -275,14 +275,14 @@ AddHandler <- function(){
       if ((nattr <- length(.rqda$.AttrNamesWidget[]))!=0) {
           enabled(button$FileAttrB) <- TRUE
           if (length(svalue(.rqda$.AttrNamesWidget))>1 || nattr>1) {
-              svalue(button$FileAttrB) <- "Attributes"
+              svalue(button$FileAttrB) <- gettext("Attributes", domain = "R-RQDA")
           }
       }
   }
 }
                     )
 
-  add3rdmousepopupmenu(.rqda$.fnames_rqda, FileNamesWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.fnames_rqda, GetFileNamesWidgetMenu())
   ## right click to add file to a case category
 
   addhandlerdoubleclick(.rqda$.fnames_rqda, handler <- function(h,...) {
@@ -298,13 +298,13 @@ AddHandler <- function(){
       if (length(Fid <- GetFileId(condition=.rqda$TOR,type="coded"))>0){
        retrieval(Fid=Fid,CodeNameWidget=.rqda$.codes_rqda)
       } else {
-        gmessage("No coding associated with this code.",container=TRUE)
+        gmessage(gettext("No coding associated with this code.", domain = "R-RQDA"),container=TRUE)
         }
   }
     }
                         )
 
-  add3rdmousepopupmenu(.rqda$.codes_rqda,CodesNamesWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.codes_rqda, GetCodesNamesWidgetMenu())
 
   addHandlerClicked(.rqda$.codes_rqda,handler <- function(h,...){
     ClickHandlerFun(.rqda$.codes_rqda,buttons=c("MarCodB1"),codingTable=.rqda$codingTable)
@@ -325,7 +325,7 @@ AddHandler <- function(){
                     )
 
   addhandlerdoubleclick(.rqda$.CasesNamesWidget, handler=function(h,...) {
-    MemoWidget("Case",.rqda$.CasesNamesWidget,"cases")
+    MemoWidget(gettext("Case", domain = "R-RQDA"),.rqda$.CasesNamesWidget,"cases")
     }
                         )
 
@@ -338,7 +338,7 @@ AddHandler <- function(){
       if ((nattr <- length(.rqda$.AttrNamesWidget[]))!=0) {
           enabled(button$CasAttrB) <- TRUE
           if (length(svalue(.rqda$.AttrNamesWidget))>1 || nattr>1) {
-              svalue(button$CasAttrB) <- "Attributes"
+              svalue(button$CasAttrB) <- gettext("Attributes", domain = "R-RQDA")
           }
       }
       enabled(.rqda$.FileofCase) <- TRUE
@@ -350,7 +350,7 @@ AddHandler <- function(){
                                       )
                               )[,1]
       freq <- RQDAQuery(sprintf("select count(distinct fid) as freq from caselinkage where status=1 and caseid=%s", currentCid))$freq
-      names(.rqda$.CasesNamesWidget) <- sprintf("Selected case id is %i__%s files", currentCid, freq)
+      names(.rqda$.CasesNamesWidget) <- sprintf(gettext("Selected case id is %i__%i files", domain = "R-RQDA"), currentCid, freq)
       if (exists(".root_edit",envir=.rqda) && isExtant(.rqda$.root_edit)) {
         SelectedFile <- svalue(.rqda$.root_edit)
         Encoding(SelectedFile) <- "UTF-8"
@@ -407,7 +407,7 @@ AddHandler <- function(){
                                      )
                              )$catid
           if (!is.null(catid) && length(catid)==1) {
-              names(.rqda$.CodeCatWidget) <- sprintf("Selected category id is %s",catid)
+              names(.rqda$.CodeCatWidget) <- sprintf(gettext("Selected category id is %s", domain = "R-RQDA"),catid)
           }}
       UpdateCodeofCatWidget(con=.rqda$qdacon,Widget=.rqda$.CodeofCat)
       ## if (ncc>1) {
@@ -417,7 +417,7 @@ AddHandler <- function(){
   })
 
   addhandlerdoubleclick(.rqda$.AttrNamesWidget, handler=function(h,...) {
-    MemoWidget("Attributes",.rqda$.AttrNamesWidget,"attributes")
+    MemoWidget(gettext("Attributes", domain = "R-RQDA"),.rqda$.AttrNamesWidget,"attributes")
   }
                         )
 
@@ -428,27 +428,27 @@ AddHandler <- function(){
       enabled(button$AttMemB) <- TRUE
       enabled(button$SetAttClsB) <- TRUE
       if (length(svalue(.rqda$.AttrNamesWidget))>1) {
-          svalue(button$CasAttrB) <- svalue(button$FileAttrB) <- "Attributes"
+          svalue(button$CasAttrB) <- svalue(button$FileAttrB) <- gettext("Attributes", domain = "R-RQDA")
       } else {
-          svalue(button$CasAttrB) <- svalue(button$FileAttrB) <- "Attribute"
+          svalue(button$CasAttrB) <- svalue(button$FileAttrB) <- gettext("Attribute", domain = "R-RQDA")
       }
   }
 }
                     )
 
   addhandlerdoubleclick(.rqda$.CodeCatWidget, handler=function(h,...) {
-    MemoWidget("Code Category",.rqda$.CodeCatWidget,"codecat")
+    MemoWidget(gettext("Code Category", domain = "R-RQDA"),.rqda$.CodeCatWidget,"codecat")
   }
                         )
 
-  add3rdmousepopupmenu(.rqda$.CodeCatWidget, CodeCatWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.CodeCatWidget, GetCodeCatWidgetMenu())
 
   addhandlerdoubleclick(.rqda$.CodeofCat,handler=function(h,...) {
     retrieval(Fid=GetFileId(condition=.rqda$TOR,type="coded"),CodeNameWidget=.rqda$.CodeofCat)
   }
                         )
 
-  add3rdmousepopupmenu(.rqda$.CodeofCat,CodeofCatWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.CodeofCat, GetCodeofCatWidgetMenu())
 
   addHandlerClicked(.rqda$.FileCatWidget,handler <- function(h,...){
     if (length(svalue(.rqda$.FileCatWidget))>0){
@@ -461,11 +461,11 @@ AddHandler <- function(){
     }})
 
   addhandlerdoubleclick(.rqda$.FileCatWidget, handler=function(h,...) {
-    MemoWidget("File Category",.rqda$.FileCatWidget,"filecat")
+    MemoWidget(gettext("File Category", domain = "R-RQDA"),.rqda$.FileCatWidget,"filecat")
   }
                         )
 
-  add3rdmousepopupmenu(.rqda$.FileCatWidget, FileCatWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.FileCatWidget, GetFileCatWidgetMenu())
 
   addhandlerdoubleclick(.rqda$.FileofCat, handler <- function(h,...) {
     ViewFileFun(FileNameWidget=.rqda$.FileofCat)
@@ -475,7 +475,7 @@ AddHandler <- function(){
   addHandlerClicked(.rqda$.FileofCat, handler <- function(h, ...) {
     if (length(svalue(.rqda$.FileofCat))>0){
       enabled(button$FilCatDroFromB) <- TRUE
-      names(.rqda$.FileofCat) <- sprintf("Sected file id is %s",GetFileId("filecat","selected"))
+      names(.rqda$.FileofCat) <- sprintf(gettext("Selected file id is %s", domain = "R-RQDA"),GetFileId("filecat","selected"))
       if (isTRUE(.rqda$SFP)) {
         ShowFileProperty(Fid = GetFileId("file", "selected"),focus=FALSE)
       }
@@ -483,12 +483,12 @@ AddHandler <- function(){
   }
                     )
 
-  add3rdmousepopupmenu(.rqda$.FileofCat,FileofCatWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.FileofCat, GetFileofCatWidgetMenu())
 
-  add3rdmousepopupmenu(.rqda$.CasesNamesWidget, CaseNamesWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.CasesNamesWidget, GetCaseNamesWidgetMenu())
   ## popup menu by right-click on CaseNamesWidget
 
-  add3rdmousepopupmenu(.rqda$.FileofCase, FileofCaseWidgetMenu)
+  add3rdmousepopupmenu(.rqda$.FileofCase, GetFileofCaseWidgetMenu())
 
   addhandlerdoubleclick(.rqda$.FileofCase, handler <- function(h,...) {
     ViewFileFun(FileNameWidget=.rqda$.FileofCase)
@@ -500,7 +500,7 @@ AddHandler <- function(){
 
   addHandlerClicked(.rqda$.FileofCase, handler <- function(h, ...) {
     if (length(svalue(.rqda$.FileofCase))>0) {
-      names(.rqda$.FileofCase) <- sprintf("Sected file id is %s",GetFileId("case","selected"))
+      names(.rqda$.FileofCase) <- sprintf(gettext("Selected File id is %s", domain = "R-RQDA"),GetFileId("case","selected"))
      }
     if (isTRUE(.rqda$SFP)) ShowFileProperty(Fid = GetFileId("case", "selected"),focus=FALSE)
   }

--- a/R/saveAs.R
+++ b/R/saveAs.R
@@ -1,4 +1,4 @@
-saveAsButt <- function(label="Save Project As ...", container){
+saveAsButt <- function(label=gettext("Save Project As ...", domain = "R-RQDA"), container){
     saveAsB <- gbutton(text=label, container=container, handler=function(h, ...){
         saveAs()
     }
@@ -11,22 +11,22 @@ saveAs <- function(newpath=NULL) {
     oldpath <- dbGetInfo(.rqda$qdacon)$dbname
     if (Encoding(oldpath)=="unknown") Encoding(oldpath) <- "UTF-8"
     if (is.null(newpath)) {
-        newpath <- gfile(type="save",text = "Type a new file name and click OK.",filter = list("RQDA" = list(patterns = c("*.rqda$"))))
+        newpath <- gfile(type="save",text = gettext("Type a new file name and click OK.", domain = "R-RQDA"),filter = list("RQDA" = list(patterns = c("*.rqda$"))))
         if (Encoding(newpath) != "UTF-8") Encoding(newpath) <- "UTF-8"
         newpath <- sprintf("%s.rqda", newpath)
     }
     override <- TRUE
     if (fexist <- file.exists(newpath)) {
-        override <- gconfirm("Over write existing project?",icon="warning")
+        override <- gconfirm(gettext("Overwrite existing project?", domain = "R-RQDA"),icon="warning")
         if (file.access(newpath, 2) != 0 && override) {
             override <- FALSE
-            gmessage("You have no write permission to overwrite it.",container=TRUE,icon="error")
+            gmessage(gettext("You have no write permission to overwrite it.", domain = "R-RQDA"),container=TRUE,icon="error")
         }
     }
     if (!fexist | override ){
         succeeded <- file.copy(from=oldpath, to=newpath,overwrite=override)
     }
-    if (!succeeded) gmessage("Failed to save the project to the new location.",container=TRUE,icon="error")
+    if (!succeeded) gmessage(gettext("Failed to save the project to the new location.", domain = "R-RQDA"),container=TRUE,icon="error")
     closeProjBF()
     ## this must be placed before closeProject() because .fnames_rqda[] <- NULL will triger Clicked handler
     closeProject()

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,7 +8,7 @@ rename <- function(from,to,table=c("source","freecode","cases","codecat","fileca
       exists <- dbGetQuery(.rqda$qdacon, sprintf("select * from %s where name = '%s' ",table, enc(to)))
       ## should check it there is any dupliation in the table
       if (nrow(exists) > 0) {
-          gmessage("The new name is duplicated. Please use another new name.",container=TRUE)
+          gmessage(gettext("The new name is duplicated. Please use another new name.", domain = "R-RQDA"),container=TRUE)
       } else {
           dbGetQuery(.rqda$qdacon, sprintf("update '%s' set name = '%s' where name = '%s' ",table, enc(to), enc(from)))
       }
@@ -85,7 +85,7 @@ MemoWidget <- function(prefix,widget,dbTable){
   if (is_projOpen(envir=.rqda,"qdacon")) {
       Selected <- svalue(widget)
       if (length(Selected)==0){
-        gmessage("Select first.",icon="error",container=TRUE)
+        gmessage(gettext("Select first.", domain = "R-RQDA"),icon="error",container=TRUE)
       }
       else {
           CloseYes <- function(currentCode){
@@ -95,7 +95,7 @@ MemoWidget <- function(prefix,widget,dbTable){
                   return(TRUE) } else {
                       if (is.na(InRQDA) && withinWidget=="")  {
                           return(TRUE) } else {
-                      val <- gconfirm("The memo has been change, Close anyway?",container=TRUE)
+                      val <- gconfirm(gettext("The memo has been changed. Close anyway?", domain = "R-RQDA"),container=TRUE)
                   }
                       return(val)
                   }
@@ -109,7 +109,7 @@ MemoWidget <- function(prefix,widget,dbTable){
               IfCont <- CloseYes(currentCode=prvSelected)}
           if ( inherits(IsOpen,"simpleError") || IfCont){ ## if not open or the same.
               tryCatch(eval(parse(text=sprintf("dispose(.rqda$.%smemo)",prefix))),error=function(e) {})
-              gw <- gwindow(title=sprintf("%s Memo:%s",prefix,Selected),
+              gw <- gwindow(title=sprintf(gettext("%s Memo:%s", domain = "R-RQDA"),prefix,Selected),
                             parent=getOption("widgetCoordinate"),
                             width = getOption("widgetSize")[1],
                             height = getOption("widgetSize")[2]
@@ -120,7 +120,7 @@ MemoWidget <- function(prefix,widget,dbTable){
               assign(sprintf(".%smemo2",prefix),
                      gpanedgroup(horizontal = FALSE, container=get(sprintf(".%smemo",prefix),envir=.rqda)),
                      envir=.rqda)
-              mbut <- gbutton("Save Memo",container=get(sprintf(".%smemo2",prefix),envir=.rqda),handler=function(h,...){
+              mbut <- gbutton(gettext("Save Memo", domain = "R-RQDA"),container=get(sprintf(".%smemo2",prefix),envir=.rqda),handler=function(h,...){
                   newcontent <- svalue(W)
                   newcontent <- enc(newcontent,encoding="UTF-8") ## take care of double quote.
                   dbGetQuery(.rqda$qdacon,sprintf("update %s set memo='%s' where name='%s'",dbTable,newcontent,enc(Selected)))
@@ -157,7 +157,7 @@ getAnnos <- function(type="file"){
         Encoding(annos$name) <- "UTF-8"
     }
     attr(annos,"field.name") <- "annotation"
-    attr(annos,"descr") <- sprintf("%i %s", nrow(annos), ngettext(nrow(annos),"annotation","annotations"))
+    attr(annos,"descr") <- sprintf("%i %s", nrow(annos), ngettext(nrow(annos),"annotation","annotations", domain = "R-RQDA"))
     class(annos) <- c("annotations","Info4Widget", "data.frame")
     annos
 }
@@ -170,7 +170,7 @@ getMemos <- function(type="codes"){
     }
     class(memos) <- c("memos","Info4Widget","data.frame")
     attr(memos,"field.name") <- "memo"
-    attr(memos,"descr") <- sprintf("%i code %s", nrow(memos), ngettext(nrow(memos),"memo","memos"))
+    attr(memos,"descr") <- sprintf("%i code %s", nrow(memos), ngettext(nrow(memos),"memo","memos", domain = "R-RQDA"))
     memos
 }
 
@@ -195,7 +195,7 @@ print.Info4Widget <- function(x, ...){
         CallBackFUN
     }
     if (nrow(x) == 0)
-        gmessage("No Information is collected.", container = TRUE)
+        gmessage(gettext("No Information is collected.", domain = "R-RQDA"), container = TRUE)
     else {
         field.name <-attr(x,"field.name")
         .gw <- gwindow(title = attr(x,"descr"), parent = getOption("widgetCoordinate"),
@@ -217,7 +217,7 @@ print.Info4Widget <- function(x, ...){
             ## anchorcreated <- buffer$createChildAnchor(iter)
             ## iter$BackwardChar()
             ## anchor <- iter$getChildAnchor()
-            ## lab <- gtkLabelNew("Back")
+            ## lab <- gtkLabelNew(gettext("Back", domain = "R-RQDA"))
             ## widget <- gtkEventBoxNew()
             ## widget$Add(lab)
             ## gSignalConnect(widget, "button-press-event", ComputeCallbackFun(x[["filename"]],
@@ -255,7 +255,7 @@ GetCodingTable <- function(){
       Encoding(Codings$codename) <- Encoding(Codings$filename) <- "UTF-8"
     }
    ## if (!all (all.equal(Codings$cid,Codings$cid2),all.equal(Codings$fid,Codings$fid2))){
-   ##   stop("Errors!") ## check to make sure the sql is correct
+   ##   stop("Errors!", domain = "R-RQDA") ## check to make sure the sql is correct
    ## }
     class(Codings) <- c("codingTable","data.frame")
     Codings
@@ -322,9 +322,9 @@ searchFiles <- SearchFiles <- function(pattern,content=FALSE,Fid=NULL,Widget=NUL
             eval(parse(text=sprintf(".rqda$%s[] <- ans$name",Widget)))
             ## eval(substitute(widget[] <- ans$name,list(widget=quote(Widget))))
         }
-        cat(sprintf("%s retrieved file(s).", nrow(ans)))
+        cat(sprintf(gettext("%i retrieved file(s).", domain = "R-RQDA"), nrow(ans)))
         invisible(ans)
-    } else cat("Open a project first.\n")
+    } else cat(gettext("Open a project first.\n", domain = "R-RQDA"))
 }
 
 RunOnSelected <- function(x,multiple=TRUE,expr,enclos=parent.frame(),title=NULL,
@@ -340,10 +340,10 @@ RunOnSelected <- function(x,multiple=TRUE,expr,enclos=parent.frame(),title=NULL,
   ##x1@widget@widget$parent$parent$parent$SetTitle(title)
   ##x1@widget@widget$parent$parent$parent$SetDefaultSize(200, 500)
   x2<-gtable(x,multiple=multiple,container=x1,expand=TRUE)
-  gbutton("Cancel",container=x1,handler=function(h,...){
+  gbutton(gettext("Cancel", domain = "R-RQDA"),container=x1,handler=function(h,...){
     dispose(x1)
   })
-  gbutton("OK",container=x1,handler=function(h,...){
+  gbutton(gettext("OK", domain = "R-RQDA"),container=x1,handler=function(h,...){
     Selected <- svalue(x2)
     if (Selected!=""){
       eval(h$action$expr,envir=pairlist(Selected=Selected),enclos=h$action$enclos)
@@ -351,7 +351,7 @@ RunOnSelected <- function(x,multiple=TRUE,expr,enclos=parent.frame(),title=NULL,
       ## Variable Selected will be found in env
       ## because env is parilist and there are variables not there, which will be found in enclos.
       dispose(g)
-    } else gmessage("Select before Click OK.\n",container=TRUE,icon="error")
+    } else gmessage(gettext("Select before Click OK.\n", domain = "R-RQDA"),container=TRUE,icon="error")
   },
           action=list(expr=substitute(expr),enclos=enclos)
           )
@@ -494,13 +494,13 @@ ShowFileProperty <- function(Fid = GetFileId(,"selected"),focus=TRUE) {
       Case <- RQDAQuery(sprintf("select name from cases where id in (select caseid from caselinkage where fid=%i and status=1) and status=1",Fid))$name
       if (!is.null(Fcat)) Encoding(Fcat) <- "UTF-8"
       if (!is.null(Case)) Encoding(Case) <- "UTF-8"
-      fcat <- paste(strwrap(sprintf("File Category is %s",paste(shQuote(Fcat),collapse=", ")),105,exdent=4),collapse="\n")
+      fcat <- paste(strwrap(sprintf(gettext("File Category is %s", domain = "R-RQDA"),paste(shQuote(Fcat),collapse=", ")),105,exdent=4),collapse="\n")
       Encoding(fcat) <-  "UTF-8"
-      val <- sprintf(" File ID is %i \n %s \nCase is %s",Fid,fcat,paste(shQuote(Case),collapse=", "))
+      val <- sprintf(gettext(" File ID is %i \n %s \nCase is %s", domain = "R-RQDA"),Fid,fcat,paste(shQuote(Case),collapse=", "))
     }
-    if (length(Fid)>1) val <- "Please select one file only."
+    if (length(Fid)>1) val <- gettext("Please select one file only.", domain = "R-RQDA")
     tryCatch(svalue(.rqda$.sfp) <- val,error=function(e){
-      gw <- gwindow("File Property",parent=size(.rqda$.root_rqdagui)+c(19,-50),
+      gw <- gwindow(gettext("File Property", domain = "R-RQDA"),parent=size(.rqda$.root_rqdagui)+c(19,-50),
             width = min(c(gdkScreenWidth() - size(.rqda$.root_rqdagui)[1] -20,getOption("widgetSize")[1])),
             height = 50)
       mainIcon <- system.file("icon", "mainIcon.png", package = "RQDA")
@@ -542,14 +542,14 @@ filesCodedByNot <- function(cid, codingTable=c("coding","coding2")){
 
 nCodedByTwo <- function(FUN, codeList=NULL, print=TRUE,...){
     ## codeList is character vector of codes.
-    if (!is_projOpen(message=FALSE)) stop("No project is opened.")
+    if (!is_projOpen(message=FALSE)) stop("No project is opened.", domain = "R-RQDA")
     FUN <- match.fun(FUN)
     Cid_Name <- RQDAQuery("select id, name from freecode where status=1")
     if (is.null(codeList)) {
         codeList <- gselect.list(Cid_Name$name,multiple=TRUE)
     }
     if (length(codeList)<2) {
-        stop("The codeList should be a vector of length 2 or abvoe.")
+        stop("The codeList should be a vector of length 2 or greater.", domain = "R-RQDA")
     } else {
         cidList <- Cid_Name$id[match(codeList, Cid_Name$name)]
         ans <- matrix(nrow=length(codeList), ncol=length(codeList),dimnames=list(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,7 +14,7 @@
   options(andMethod=c("overlap","exact","inclusion"))
   assign("optOld",optOld,envir=.rqda)
   if (interactive()) {
-     packageStartupMessage("\nUse 'RQDA()' to start the programme.\n")
+     packageStartupMessage("\nUse 'RQDA()' to start the programme.\n", domain = "R-RQDA")
      RQDA()
    }
 }

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,0 +1,33 @@
+# This file is part of RQDA
+
+
+# After you add, delete or change any message in the source files, type
+#    make
+# to update the R-RQDA.pot file and the .po files.
+#
+# After you update the translations in any of the .po files, type
+#    make
+# to update the .mo files in ../inst/po/.../LC_MESSAGES
+
+
+# To add a translation for a new language:
+#
+#   1. Add the new .po and .mo files to POFILES and MOFILES lists below.
+#
+#   2. Create the R-lang.po file using as template one of the .po files from
+#      this directory.
+#
+#   3. Replace the translations with the new language translations.
+#
+#   4. Type in a terminal emulator (in this directory):
+#      make
+
+
+.POSIX:
+
+all:
+	echo 'library(tools) ; update_pkg_po("../../RQDA", bugs = "https://github.com/Ronggui/RQDA/issues")' | R --quiet --vanilla
+
+clean:
+	-rm -f *.po~ R-RQDA.pot
+

--- a/po/R-pt_BR.po
+++ b/po/R-pt_BR.po
@@ -1,0 +1,1042 @@
+# RQDA
+msgid ""
+msgstr ""
+"Project-Id-Version: RQDA\n"
+"Report-Msgid-Bugs-To: https://github.com/Ronggui/RQDA/issues\n"
+"POT-Creation-Date: 2016-10-26 21:11\n"
+"PO-Revision-Date: 2016-10-26 14:25-0300\n"
+"Last-Translator: Jakson Aquino <jalvesaq@gmail.com>\n"
+"Language-Team: pt <pt@li.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Add a new file to selected case"
+msgstr "Adicionar um novo arquivo ao caso selecionado"
+
+msgid "Enter the title"
+msgstr "Digite o título"
+
+msgid "Save"
+msgstr "Salvar"
+
+msgid "Attribute of:"
+msgstr "Atributo de:"
+
+msgid "Save and Close"
+msgstr "Salvar e Fechar"
+
+msgid "add attribute in Attrs Table first."
+msgstr "adicionar atributo na Tabela de Atributos primeiro."
+
+msgid "ADD"
+msgstr "Adicionar"
+
+msgid "Enter new Attr Name."
+msgstr "Digite um novo Nome de Atributo."
+
+msgid "Attribute should NOT contain '."
+msgstr "Atributos NÃO devem conter '."
+
+msgid "This is a reserved keyword."
+msgstr "Esta é uma palavra-chave reservada."
+
+msgid "Delete"
+msgstr "Deletar"
+
+msgid "Really delete the Attribute?"
+msgstr "Realmente deletar o Atributo?"
+
+msgid "Rename"
+msgstr "Renomear"
+
+msgid "Enter new attribute name."
+msgstr "Digite novo nome de atributo."
+
+msgid "Name duplicated. Please use another name."
+msgstr "Nome duplicado. Por favor, escolha outro."
+
+msgid "Memo"
+msgstr "Comentário"
+
+msgid "Attributes"
+msgstr "Atributos"
+
+msgid "'subset' must evaluate to logical"
+msgstr "'subset' deve ser avaliado como 'logical'"
+
+msgid "Class"
+msgstr "Classe"
+
+msgid ""
+"Set class of selected attribute.\n"
+"It can be 'numeric' or 'character'."
+msgstr ""
+"Configure a classe do atributo selecionado.\n"
+"Ela pode ser 'numeric' ou 'character'."
+
+msgid "Type of attribute"
+msgstr "Tipo de atributo"
+
+msgid "some files are not in the rqda project."
+msgstr "alguns arquivos não estão no projeto rqda."
+
+msgid "some attributes are in not the rqda project."
+msgstr "alguns atributos não estão no projeto rqda."
+
+msgid "cid should be length-1 integer vector."
+msgstr "cid deveria ser um vector de números inteiros de comprimento 1"
+
+msgid "No Codings."
+msgstr "Nenhuma codificação."
+
+msgid "Back"
+msgstr "Voltar"
+
+msgid "Enter new Case Name."
+msgstr "Digite um novo Nome de Caso"
+
+msgid "Really delete the Case?"
+msgstr "Realmente deletar o Caso?"
+
+msgid "Enter new Case name."
+msgstr "Digite um novo nome de Caso."
+
+msgid "Mark"
+msgstr "Marcar"
+
+msgid "Fail to write to database."
+msgstr "Falha ao escrever na base de dados."
+
+msgid "Unmark"
+msgstr "Desmarcar"
+
+msgid "Select a case first."
+msgstr "Selecione um caso primeiro."
+
+msgid "Attribute"
+msgstr "Atributo"
+
+msgid "Add File(s)"
+msgstr "Adicionar Arquivo(s)"
+
+msgid "All files are linked with this case."
+msgstr "Todos os arquivos estão ligados a este caso."
+
+msgid "Add New File to Selected Case"
+msgstr "Adicionar novo arquivo ao caso selecionado"
+
+msgid "Case Memo"
+msgstr "Comentário de Caso"
+
+msgid "Case"
+msgstr "Caso"
+
+msgid "Show Cases with Memo Only"
+msgstr "Mostrar somente Casos com Comentário"
+
+msgid "Add/modify Attributes..."
+msgstr "Adicionar/modificar Atributos..."
+
+msgid "View Attributes"
+msgstr "Ver Atributos"
+
+msgid "Export Case Attributes"
+msgstr "Exportar Atributos do Caso"
+
+msgid "Sort All by Created Time"
+msgstr "Ordenar Tudo por tempo de criação"
+
+msgid "Web Search"
+msgstr "Pesquisar na Internet"
+
+msgid "Add To File Category ..."
+msgstr "Adicionar a Categoria de Arquivo"
+
+msgid "Drop Selected File(s)"
+msgstr "Eliminar Arquivo(s) Selecionado(s)"
+
+msgid "Please select the Files you want to delete."
+msgstr "Por favor, selecione os Arquivos que deseja deletar."
+
+msgid "Delete %i file(s) from this category. Are you sure?"
+msgstr "Deletar %i arquivos(s) desta categoria. Tem certeza?"
+
+msgid "Delete Selected File(s)"
+msgstr "Deletar Arquivo(s) Selecionado(s)"
+
+msgid "Edit Selected File"
+msgstr "Editar Arquivo Selecionado"
+
+msgid "File Memo"
+msgstr "Comentário de Arquivo"
+
+msgid "File"
+msgstr "Arquivo"
+
+msgid "Rename selected File"
+msgstr "Renomear Arquivo Selecionado"
+
+msgid "Select a file first."
+msgstr "Selecione um arquivo primeiro."
+
+msgid "Enter new file name."
+msgstr "Digite novo nome de arquivo."
+
+msgid "Search Files within Seleted Case"
+msgstr "Pesquisar arquivos no caso selecionado"
+
+msgid "Please input a search pattern."
+msgstr "Por favor, entre um padrão de pesquisa."
+
+msgid "Error~~~."
+msgstr "Erro~~~."
+
+msgid "Show ..."
+msgstr "Mostrar ..."
+
+msgid "Show All by Sorted by Imported Time"
+msgstr "Mostrar todos ordenados por tempo de importação"
+
+msgid "Show Coded Files Only (sorted)"
+msgstr "Mostrar Somente Arquivos Codificados (ordenados)"
+
+msgid "Show Uncoded Files Only (sorted)"
+msgstr "Mostrar Somente Arquivos Não Codificados (ordenados)"
+
+msgid "Show Selected File Property"
+msgstr "Mostrar Propriedades do arquivo selecionado"
+
+msgid "Fail to write to database for case with id %i"
+msgstr "Falha ao escrever na base de dados para o caso com id %i"
+
+msgid "Enter new Code Category."
+msgstr "Digite um nova Categoria de Código."
+
+msgid "Really delete the Code Category?"
+msgstr "Realmente deletar Categoria de Código?"
+
+msgid "The Category Name is not unique."
+msgstr "O nome da Categoria não é único."
+
+msgid "Select a Code Category first."
+msgstr "Selecione uma Categoria de código primeiro."
+
+msgid "Enter new Cateory name."
+msgstr "Digite um novo Nome de Categoria."
+
+msgid "Add To"
+msgstr "Adicionar a"
+
+msgid "No free codes yet."
+msgstr "Nenhum código livre ainda."
+
+msgid "Add code(s) to the selected code category."
+msgstr "Adicionar código(s) à categoria de código selecionada."
+
+msgid "Drop From"
+msgstr "Remover de"
+
+msgid "Please select the Codes you want to delete."
+msgstr "Por favor, selecione os Códigos que deseja deletar."
+
+msgid "Delete %i code(s) from this category. Are you sure?"
+msgstr "Deletar %i código(s) desta categoria. Tem certeza?"
+
+msgid "Drop selected code(s) from code category."
+msgstr "Remover código(s) selecionados da categoria."
+
+msgid "Code Category"
+msgstr "Categoria de Código"
+
+msgid "Add New Code to Selected Category"
+msgstr "Adicionar um Novo Código à Categoria selecionada"
+
+msgid "Enter new code."
+msgstr "Digite um novo código."
+
+msgid "Select a code category first."
+msgstr "Selecionar uma categoria de código primeiro."
+
+msgid "Failed to assign code category"
+msgstr "Falha ao especificar categoria de código"
+
+msgid "Codings of selected category"
+msgstr "Codificações das categorias selecionadas"
+
+msgid "Plot Selected Code Categories"
+msgstr "Plotar Categorias de Códigos selecionadas"
+
+msgid "Plot Selected Code Categories with d3"
+msgstr "Plotar Categorias de Códigos selecionadas com d3"
+
+msgid "Sort by created time"
+msgstr "Ordenar por tempo de criação"
+
+msgid "Rename Selected Code"
+msgstr "Renomear Código Selecionado"
+
+msgid "Select a code first."
+msgstr "Selecionar um código primeiro."
+
+msgid "Enter new code name."
+msgstr "Digite um novo código."
+
+msgid "Code Memo"
+msgstr "Comentário de Código"
+
+msgid "Code"
+msgstr "Código"
+
+msgid "Cannot update Code List in the Widget. Project is closed already."
+msgstr ""
+"Não é possível atualizar lista de códigos na Interface Gráfica. O projeto já "
+"está fechado."
+
+msgid "Save Coding Memo"
+msgstr "Salvar Comentário da Codificação"
+
+msgid "No Coding associated with the selected code."
+msgstr "Nenhuma codificação associada ao código selecionado."
+
+msgid "cannot recode this text segment."
+msgstr "não é possível recodificar este segmento de texto."
+
+msgid "Selected code id is %s__%s codings"
+msgstr "ID do Código Selecionado %s__%s codificações"
+
+msgid "Recode"
+msgstr "Recodificar"
+
+msgid "No Coding associated with the '%s'."
+msgstr "Nenhuma codificação associada com o '%s'."
+
+msgid "[Annotation]"
+msgstr "[Anotação]"
+
+msgid "Save Annotation"
+msgstr "Salvar anotação"
+
+msgid "Open a file first!"
+msgstr "Abra o arquivo primeiro!"
+
+msgid "Add Code Categroy First."
+msgstr "Adicionar Categoria de Código primeiro."
+
+msgid "Fail to write to code category of %s"
+msgstr "Falha ao escrever na categoria de código de %s"
+
+msgid "Add"
+msgstr "Adicionar"
+
+msgid "Really delete the code?"
+msgstr "Realmente deletar o código?"
+
+msgid "No codings associated with this code."
+msgstr "Nenhuma codificação associada a este código."
+
+msgid "Retrieve codings of the selected code."
+msgstr "Obter codificações do códigos selecionados."
+
+msgid "Open a file first."
+msgstr "Abrir um arquivo primeiro."
+
+msgid "Fail to write to data base."
+msgstr "Falha ao escrever na base de dados."
+
+msgid "Select a code and one of its codings exactly first."
+msgstr "Selecione um código e um de suas codificações primeiro."
+
+msgid "C-Memo"
+msgstr "Coment-C"
+
+msgid "code"
+msgstr "código"
+
+msgid "Memo for selected code."
+msgstr "Comentário para o código selecionado."
+
+msgid "C2Memo"
+msgstr "Coment-C2"
+
+msgid "[Coding Memo]"
+msgstr "[Comentário de Codificação]"
+
+msgid "select a code first."
+msgstr "selecione um código primeiro."
+
+msgid "Select the exact CODING AND the corresponding CODE first."
+msgstr "Selecione a CODIFICAÇÃO exata E o correspondente CÓDIGO primeiro."
+
+msgid "Memo for a Coding."
+msgstr "Comentário para uma Codificação."
+
+msgid "Add Anno"
+msgstr "Adicionar Anotação"
+
+msgid ""
+"Add new annotation to the open file\n"
+"at position of cursor."
+msgstr ""
+"Adicionar nova anotação ao arquivo aberto\n"
+"na posição do cursor."
+
+msgid "Add To Code Category..."
+msgstr "Adicionar a Categoria de Código..."
+
+msgid "All Code Memos"
+msgstr "Todos os Comentários de Código"
+
+msgid "All Annotations"
+msgstr "Todas as Anotações"
+
+msgid "Codings of Multiple Codes"
+msgstr "Codificações de Múltiplos Códigos"
+
+msgid "Export Codings as HTML"
+msgstr "Exportar Codificações como HTML"
+
+msgid "Type a name for the exported codings and click OK."
+msgstr "Digite um nome para as codificações exportadas e clique OK."
+
+msgid "Highlight All Codings"
+msgstr "Realçar Todas as Codificações"
+
+msgid "Highlight Codings with Memo"
+msgstr "Realçar Codificações com Comentários"
+
+msgid "Merge Selected with..."
+msgstr "Juntar Selecionado com..."
+
+msgid "Show Codes With Codings"
+msgstr "Mostrar Códigos com Codificações"
+
+msgid "Show Codes Without Codings"
+msgstr "Mostrar Códigos sem Codificações"
+
+msgid "Show Codes With Code Category"
+msgstr "Mostrar Códigos com Categoria de Código"
+
+msgid "All codes are assiged to code category."
+msgstr "Todos os códigos estão categorizados."
+
+msgid "Show Codes Without Code Category"
+msgstr "Mostrar Códigos sem Categoria de Código"
+
+msgid "Show Codes With Memo"
+msgstr "Mostrar Códigos com Comentário"
+
+msgid "No Code with memo."
+msgstr "Nenhum Código com Comentário."
+
+msgid "Show Codes Without Memo"
+msgstr "Mostrar Códigos sem Comentários"
+
+msgid "Show Codes With Selected File"
+msgstr "Mostrar Códigos com Arquivo Selecionado"
+
+msgid "Set Coding Mark Color"
+msgstr "Configurar Cor da Marca da Codificação"
+
+msgid "Sort: By Created Time"
+msgstr "Ordenar: Por Tempo de Criação"
+
+msgid "Sort: Most to Least Frequently Used"
+msgstr "Ordenar: Do Mais para o Menos frequentemente usado"
+
+msgid "Sort: Least to Most Frequently Used"
+msgstr "Ordenar: Do Menos para o Mais frequentemente usado"
+
+msgid "Import"
+msgstr "Importar"
+
+msgid "New"
+msgstr "Novo"
+
+msgid "Open"
+msgstr "Abrir"
+
+msgid "Save To Project"
+msgstr "Salvar no Projeto"
+
+msgid "Save and close"
+msgstr "Salvar e fechar"
+
+msgid "Add New File ..."
+msgstr "Adicionar Novo Arquivo ..."
+
+msgid "Add To Case ..."
+msgstr "Adicionar ao Caso"
+
+msgid "Add/modify Attributes of The Open File..."
+msgstr "Adicionar/modificar Atributos do arquivo aberto"
+
+msgid "Codings of selected file(s)"
+msgstr "Codificações do(s) arquivo(s) selecionado(s)"
+
+msgid "No coded file is selected."
+msgstr "Nenhum arquivo codificado está selecionado."
+
+msgid "Export File Attributes"
+msgstr "Exportar Atributos do Arquivo"
+
+msgid "Edit Seleted File"
+msgstr "Editar Arquivo Selecionado"
+
+msgid "Export Coded file as HTML"
+msgstr "Exportar arquivo codificado como HTML"
+
+msgid "File Annotations"
+msgstr "Anotações do Arquivo"
+
+msgid "Import PDF Highligts via rjpod (selector)"
+msgstr "Importar realces de PDF via rjpod (selector)"
+
+msgid "Import PDF Highligts via rjpod (file path)"
+msgstr "Importar realces de PDF via rjpod (caminho de arquivo)"
+
+msgid "Enter a pdf file path"
+msgstr "Digite um caminho para arquivo pdf"
+
+msgid "Open Selected File"
+msgstr "Abrir o Arquivo Selecionado"
+
+msgid "Open Previous Coded File"
+msgstr "Abrir Arquivo codificado anterior"
+
+msgid "Search for a Word"
+msgstr "Procurar uma palavra"
+
+msgid "Search all files ..."
+msgstr "Procurar em todos os arquivos ..."
+
+msgid "Show All Sorted By Imported Time"
+msgstr "Mostrar todos ordenados por tempo de importação"
+
+msgid "Show Coded Files Sorted by Imported time"
+msgstr "Mostrar arquivos codificados ordenados por tempo de importação"
+
+msgid "Show Uncoded Files Sorted by Imported time"
+msgstr "Mostrar arquivos não codificados ordenados por tempo de importação"
+
+msgid "Show Files With Annotation"
+msgstr "Mostrar arquivos com anotações"
+
+msgid "No file with memo."
+msgstr "Nenhum arquivo com comentário."
+
+msgid "Show Files Without Annotation"
+msgstr "Mostrar arquivos sem anotações"
+
+msgid "All files have annotation."
+msgstr "Todos os arquivos têm anotações"
+
+msgid "Show Files With Memo"
+msgstr "Mostrar arquivos com Comentário"
+
+msgid "Show Files Without Memo"
+msgstr "Mostrar arquivos sem comentário"
+
+msgid "No file is found."
+msgstr "Nenhum arquivo encontrado."
+
+msgid "Show Files Without File Category"
+msgstr "Mostrar Arquivos sem Categoria de Arquivo"
+
+msgid "All are linked with file category."
+msgstr "Todos estão ligados com a categoria de arquivo."
+
+msgid "Show Files With No Case"
+msgstr "Mostrar arquivo sem casos"
+
+msgid "All are linked with cases."
+msgstr "Todos estão ligados com casos."
+
+msgid "Enter new File Category."
+msgstr "Digite um nova Categoria de Arquivo."
+
+msgid "Really delete the File Category?"
+msgstr "Realmente deletar Categoria de Arquivo?"
+
+msgid "File Category"
+msgstr "Categoria de Arquivo"
+
+msgid "Memo of file category."
+msgstr "Comentário de categoria de arquivo."
+
+msgid "AddTo"
+msgstr "Adicionar A"
+
+msgid "No files Yet."
+msgstr "Nenhum arquivo ainda."
+
+msgid "Add file(s) to the selected file category."
+msgstr "Adicionar arquivo(s) à categoria de arquivo selecionada."
+
+msgid "DropFrom"
+msgstr "Remover De"
+
+msgid "Drop selected file(s) from file category."
+msgstr "Remover arquivo(s) selecionados da categoria."
+
+msgid "Delete all files of selected category"
+msgstr "Deletar todos os arquivos da categoria selecionada"
+
+msgid "Move To File Category ..."
+msgstr "Mover para Categoria de Arquivo ..."
+
+msgid "Search Files Within Categroy"
+msgstr "Pesquisar Arquivos na Categoria"
+
+msgid "Delete selected File(s)"
+msgstr "Deletar Arquivo(s) Selecionado(s)"
+
+msgid "Show All By Imported Time"
+msgstr "Mostrar Todos por Tempo de Importação"
+
+msgid "A file with the same name exists in the database!"
+msgstr "Um arquivo com o mesmo nome existe na base de dados"
+
+msgid "Save File"
+msgstr "Salvar Arquivo"
+
+msgid "Open a project first."
+msgstr "Abrir um projeto primeiro."
+
+msgid "Save memo"
+msgstr "Salvar comentário"
+
+msgid "select one file category only."
+msgstr "selecione uma categoria de arquivo somente."
+
+msgid "more than one file categories are selected"
+msgstr "mais de uma categoria de arquivo está selecionada"
+
+msgid "Add File Categroy first."
+msgstr "Adicionar Categoria de Arquivo primeiro."
+
+msgid "Fail to write to file category of %s"
+msgstr "Falha ao escrever categoria de arquivo de %s"
+
+msgid "Reach the end."
+msgstr "Fim alcançado."
+
+msgid "Search next"
+msgstr "Procurar próximo"
+
+msgid "Restart"
+msgstr "Reiniciar"
+
+msgid "Really delete the journal?"
+msgstr "Realmente deletar o item do diário?"
+
+msgid "Enter new journal name."
+msgstr "Digite novo nome de item do diário."
+
+msgid "Save Journal"
+msgstr "Salvar Diário"
+
+msgid "Select first."
+msgstr "Selecione primeiro."
+
+msgid "The Journal has been changed. Close anyway?"
+msgstr "O item do Diário foi modificado. Fechar mesmo assim?"
+
+msgid "Profile Matrix - %s"
+msgstr "Matriz de perfis - %s"
+
+msgid "New Project"
+msgstr "Novo Projeto"
+
+msgid "Type a name for the new project and click OK."
+msgstr "Digite um nome para o projeto e clique OK."
+
+msgid "Open Project"
+msgstr "Abrir Projeto"
+
+msgid "Select a *.rqda file and click OK."
+msgstr "Selecione um arquivo *.rqda e clique OK."
+
+msgid "Opening ..."
+msgstr "Abrindo ..."
+
+msgid "Closing ..."
+msgstr "Fechando ..."
+
+msgid "No project is open."
+msgstr "Nenhum projeto está aberto."
+
+msgid "Files"
+msgstr "Arquivos"
+
+msgid "Codes List"
+msgstr "Lista de Códigos"
+
+msgid "Codes of This Category"
+msgstr "Códigos desta Categoria"
+
+msgid "Cases"
+msgstr "Casos"
+
+msgid "Files of This Case"
+msgstr "Arquivos deste Caso"
+
+msgid "Files of This Category"
+msgstr "Arquivos desta Categoria"
+
+msgid "Close Project"
+msgstr "Fechar Projeto"
+
+msgid "Backup Project"
+msgstr "Cópia de Segurança do Projeto"
+
+msgid "Project Memo"
+msgstr "Comentário de Projeto"
+
+msgid "Clean Project"
+msgstr "Limpar Projeto"
+
+msgid "Close All Codings"
+msgstr "Fechar todas as Codificações"
+
+msgid "No write permission."
+msgstr "Sem permissão de escrita."
+
+msgid "Overwrite existing project?"
+msgstr "Sobrescrever o projeto existente?"
+
+msgid "You have no write permission to overwrite it."
+msgstr "Você não tem permissão de escrita para sobrescrevê-lo"
+
+msgid ""
+"You don't have write access to the *.rqda file. You can only read the "
+"project."
+msgstr ""
+"Você não tem permissão de escrita para o arquivo *.rqda. Você pode somente "
+"ler o projeto"
+
+msgid "You don't have read access to the *.rqda file. Fail to open."
+msgstr ""
+"Você não tem permissão de leitura para o arquivo *.rqda. Falha ao abrir."
+
+msgid "Closing project failed."
+msgstr "Falha ao fechar projeto."
+
+msgid "No Project is Open."
+msgstr "Nenhum Projeto está Aberto."
+
+msgid "Succeeded!"
+msgstr "Sucesso!"
+
+msgid "Fail to back up the project."
+msgstr "Falha ao fazer cópia de segurança do projeto."
+
+msgid "The memo has bee change. Close anyway?"
+msgstr "O comentário foi modificado. Fechar mesmo assim?"
+
+msgid "Settings"
+msgstr "Configurações"
+
+msgid "Name of Coder"
+msgstr "Nome do Codificador"
+
+msgid "File Encoding"
+msgstr "Codificação do Arquivo"
+
+msgid "Color for Coding"
+msgstr "Cor para Codificação"
+
+msgid "Color for Case"
+msgstr "Cor para Caso"
+
+msgid "Current coding table"
+msgstr "Tabela de codificação atual"
+
+msgid "Byte Order Mark"
+msgstr "Marca de Ordem de Byte"
+
+msgid "Show File Property"
+msgstr "Mostrar Propriedades do Arquivo"
+
+msgid "Type of Retrieval"
+msgstr "Tipo de Recuperação"
+
+msgid "unconditional"
+msgstr "incondicional"
+
+msgid "case"
+msgstr "caso"
+
+msgid "filecategory"
+msgstr "categoria de arquivo"
+
+msgid "both"
+msgstr "ambos"
+
+msgid "Click to set font"
+msgstr "Clique para configurar a fonte"
+
+msgid "Set fonts for memo widgets."
+msgstr "Configurar fonte para editor de comentários."
+
+msgid "Default"
+msgstr "Padrão"
+
+msgid "OK"
+msgstr "OK"
+
+msgid "Change color."
+msgstr "Mudar cor."
+
+msgid "Select Color"
+msgstr "Selecionar Cor"
+
+msgid "Changing color"
+msgstr "Mudança de cor"
+
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgid "Are you sure to clean the coding table?"
+msgstr "Tem certeza de limpar a tabela de codificação?"
+
+msgid "One code has empty coding."
+msgstr "Um código tem codificação vazia."
+
+msgid "Each line represents one relation only"
+msgstr "Cada linha representa apenas uma relação"
+
+msgid "index1 and index2 must be vector."
+msgstr "index1 e index2 devem ser vectores."
+
+msgid "index1 or index2 should not have any NA."
+msgstr "index1 ou index2 não devem ter nenhum NA."
+
+msgid "No coding in this project."
+msgstr "Nenhuma codificação neste projeto."
+
+msgid "Codes without codings dropped."
+msgstr "Códigos não usados serão eliminados."
+
+msgid "The codeList should be a vector of length 2 or greater"
+msgstr "A lista de códigos deve ser um vector de tamanho 2 ou maior."
+
+msgid "RQDA has been launched."
+msgstr "RQDA foi iniciado."
+
+msgid "RQDA: Qualitative Data Analysis"
+msgstr "RQDA: Análise de Dados Qualitativos"
+
+msgid "Project"
+msgstr "Projeto"
+
+msgid "Save Project As"
+msgstr "Salvar Projeto como"
+
+msgid "Path of current project:"
+msgstr "Caminho para o projeto atual:"
+
+msgid "Author: <ronggui.huang@gmail.com>"
+msgstr "Autor: <ronggui.huang@gmail.com>"
+
+msgid "Help: click to join rqda-help mailing list"
+msgstr "Ajuda: clique para juntar-se à mailing list rqda-help"
+
+msgid "License: BSD"
+msgstr "Licença: BSD"
+
+msgid "Version:"
+msgstr "Versão:"
+
+msgid "Year:"
+msgstr "Ano:"
+
+msgid "Please cite this package."
+msgstr "Por favor, cite este pacote."
+
+msgid "About"
+msgstr "Sobre"
+
+msgid "Codes"
+msgstr "Códigos"
+
+msgid "Anno"
+msgstr "Anotação"
+
+msgid "Coding"
+msgstr "Codificação"
+
+msgid ""
+"Code\n"
+"Categories"
+msgstr ""
+"Categorias\n"
+"de Códigos"
+
+msgid "Please click Update"
+msgstr "Por favor, clique Atualizar"
+
+msgid "UnMark"
+msgstr "Desmarcar"
+
+msgid "Unlink"
+msgstr "Desligar"
+
+msgid "Link"
+msgstr "Ligar"
+
+msgid "Profile"
+msgstr "Perfil"
+
+msgid ""
+"File\n"
+"Categories"
+msgstr ""
+"Categorias\n"
+"de Arquivos"
+
+msgid "Journals"
+msgstr "Diário"
+
+msgid ""
+"Really EXIT?\n"
+"\n"
+"You can use RQDA() to start this program again."
+msgstr ""
+"Realmente SAIR?\n"
+"\n"
+"Você pode usar 'RQDA()' para iniciar o programa novamente."
+
+msgid "Selected File id is %s"
+msgstr "ID do Arquivo Selecionado %s"
+
+msgid "No coding associated with this code."
+msgstr "Nenhuma codificação associada a este projeto."
+
+msgid "Selected case id is %i__%i files"
+msgstr "ID do caso selecionado %i__%i arquivos"
+
+msgid "Selected category id is %s"
+msgstr "O id do Categoria selecionada é %s"
+
+msgid "Selected file id is %s"
+msgstr "ID do arquivo selecionado %s"
+
+msgid "Save Project As ..."
+msgstr "Salvar Projeto como ..."
+
+msgid "Type a new file name and click OK."
+msgstr "Digite um nome para o arquivo e clique OK."
+
+msgid "Failed to save the project to the new location."
+msgstr "Falha ao salvar o projeto no novo local."
+
+msgid "The new name is duplicated. Please use another new name."
+msgstr "O novo nome é duplicado. Por favor, escolha outro."
+
+msgid "The memo has been changed. Close anyway?"
+msgstr "O comentário foi modificado. Fechar mesmo assim?"
+
+msgid "%s Memo:%s"
+msgstr "Comentário de %s: %s"
+
+msgid "Save Memo"
+msgstr "Salvar Comentário"
+
+msgid "No Information is collected."
+msgstr "Nenhuma Informação coletada."
+
+msgid "%i retrieved file(s)."
+msgstr "%i retrieved file(s)."
+
+msgid "Select before Click OK."
+msgstr "Selecione antes de clicar OK."
+
+msgid "File Category is %s"
+msgstr "A Categoria do Arquivo é %s"
+
+msgid ""
+"File ID is %i \n"
+" %s \n"
+"Case is %s"
+msgstr ""
+"O ID do arquivo é %i \n"
+" %s \n"
+"Caso é %s"
+
+msgid "Please select one file only."
+msgstr "Por favor, selecione um somente arquivo."
+
+msgid "File Property"
+msgstr "Propriedades do Arquivo"
+
+msgid "No project is opened."
+msgstr "Nenhum projeto está aberto."
+
+msgid "The codeList should be a vector of length 2 or greater."
+msgstr "A lista de códigos deve ser um vector de tamanho 2 ou maior."
+
+msgid "Use 'RQDA()' to start the programme."
+msgstr "Use 'RQDA()' para iniciar o programa."
+
+msgid "1 coding from %i file"
+msgid_plural "1 coding from %i files"
+msgstr[0] "1 codificação de %i arquivo"
+msgstr[1] "1 codificação de %i arquivos"
+
+msgid "%i codings from %i file"
+msgid_plural "%i codings from %i files"
+msgstr[0] "%i codificações de %i arquivo"
+msgstr[1] "%i codificações de %i arquivos"
+
+msgid "1 retrieved coding: \"%s\" from %i file"
+msgid_plural "1 retrieved coding: \"%s\" from %i files"
+msgstr[0] "1 codificação recuperada: \"%s\" de %i arquivo"
+msgstr[1] "1 codificação recuperada: \"%s\" de %i arquivos"
+
+msgid "%i retrieved codings: \"%s\" from %i file"
+msgid_plural "%i retrieved codings: \"%s\" from %i files"
+msgstr[0] "%i codificações recuperadas: \"%s\" de %i arquivo"
+msgstr[1] "%i codificações recuperadas: \"%s\" de %i arquivos"
+
+msgid "%i Coding of <a id='%s'>\"%s\"</a> from %s file."
+msgid_plural "%i Coding of <a id='%s'>\"%s\"</a> from %s files."
+msgstr[0] "%i Codificação de <a id='%s'>\"%s\"</a> em %s arquivo."
+msgstr[1] "%i Codificação de <a id='%s'>\"%s\"</a> em %s arquivos."
+
+msgid "%i Codings of <a id='%s'>\"%s\"</a> from %s file."
+msgid_plural "%i Codings of <a id='%s'>\"%s\"</a> from %s files."
+msgstr[0] "%i Codificações de <a id='%s'>\"%s\"</a> em %s arquivo."
+msgstr[1] "%i Codificações de <a id='%s'>\"%s\"</a> em %s arquivos."
+
+msgid "Annotation"
+msgid_plural "Annotations"
+msgstr[0] "Anotação"
+msgstr[1] "Anotações"
+
+msgid "Really delete the file?"
+msgid_plural "Really delete the files?"
+msgstr[0] "Realmente deletar o arquivo?"
+msgstr[1] "Realmente deletar os arquivos?"
+
+msgid "1 retrieved coding from %i file"
+msgid_plural "1 retrieved coding from %i files"
+msgstr[0] "1 codificação recuperada de %i arquivo"
+msgstr[1] "1 codificação recuperada de %i arquivos"
+
+msgid "%i retrieved codings from %i file"
+msgid_plural "%i retrieved codings from %i files"
+msgstr[0] "%i codificações recuperadas de %i arquivo"
+msgstr[1] "%i codificações recuperadas de %i arquivos"
+
+msgid "annotation"
+msgid_plural "annotations"
+msgstr[0] "anotação"
+msgstr[1] "anotações"
+
+msgid "memo"
+msgid_plural "memos"
+msgstr[0] "comentário"
+msgstr[1] "comentários"

--- a/po/R-pt_PT.po
+++ b/po/R-pt_PT.po
@@ -1,0 +1,1042 @@
+# RQDA
+msgid ""
+msgstr ""
+"Project-Id-Version: RQDA\n"
+"Report-Msgid-Bugs-To: https://github.com/Ronggui/RQDA/issues\n"
+"POT-Creation-Date: 2016-10-26 21:11\n"
+"PO-Revision-Date: 2016-10-26 21:14-0300\n"
+"Last-Translator: Jakson Aquino <jalvesaq@gmail.com>\n"
+"Language-Team: pt <pt@li.org>\n"
+"Language: pt_PT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Add a new file to selected case"
+msgstr "Adicionar um novo ficheiro ao caso seleccionado"
+
+msgid "Enter the title"
+msgstr "Digite o título"
+
+msgid "Save"
+msgstr "Guardar"
+
+msgid "Attribute of:"
+msgstr "Atributo de:"
+
+msgid "Save and Close"
+msgstr "Guardar e Fechar"
+
+msgid "add attribute in Attrs Table first."
+msgstr "adicionar atributo na Tabela de Atributos primeiro."
+
+msgid "ADD"
+msgstr "Adicionar"
+
+msgid "Enter new Attr Name."
+msgstr "Digite um novo Nome de Atributo."
+
+msgid "Attribute should NOT contain '."
+msgstr "Atributos NÃO devem conter '."
+
+msgid "This is a reserved keyword."
+msgstr "Esta é uma palavra-chave reservada."
+
+msgid "Delete"
+msgstr "Apagar"
+
+msgid "Really delete the Attribute?"
+msgstr "Realmente apagar o Atributo?"
+
+msgid "Rename"
+msgstr "Renomear"
+
+msgid "Enter new attribute name."
+msgstr "Digite novo nome de atributo."
+
+msgid "Name duplicated. Please use another name."
+msgstr "Nome duplicado. Por favor, escolha outro."
+
+msgid "Memo"
+msgstr "Comentário"
+
+msgid "Attributes"
+msgstr "Atributos"
+
+msgid "'subset' must evaluate to logical"
+msgstr "'subset' deve ser avaliado como 'logical'"
+
+msgid "Class"
+msgstr "Classe"
+
+msgid ""
+"Set class of selected attribute.\n"
+"It can be 'numeric' or 'character'."
+msgstr ""
+"Configure a classe do atributo seleccionado.\n"
+"Ela pode ser 'numeric' ou 'character'."
+
+msgid "Type of attribute"
+msgstr "Tipo de atributo"
+
+msgid "some files are not in the rqda project."
+msgstr "alguns ficheiros não estão no projecto rqda."
+
+msgid "some attributes are in not the rqda project."
+msgstr "alguns atributos não estão no projecto rqda."
+
+msgid "cid should be length-1 integer vector."
+msgstr "cid deveria ser um vector de números inteiros de comprimento 1"
+
+msgid "No Codings."
+msgstr "Nenhuma codificação."
+
+msgid "Back"
+msgstr "Voltar"
+
+msgid "Enter new Case Name."
+msgstr "Digite um novo Nome de Caso"
+
+msgid "Really delete the Case?"
+msgstr "Realmente apagar o Caso?"
+
+msgid "Enter new Case name."
+msgstr "Digite um novo nome de Caso."
+
+msgid "Mark"
+msgstr "Marcar"
+
+msgid "Fail to write to database."
+msgstr "Falha ao escrever na base de dados."
+
+msgid "Unmark"
+msgstr "Desmarcar"
+
+msgid "Select a case first."
+msgstr "Seleccione um caso primeiro."
+
+msgid "Attribute"
+msgstr "Atributo"
+
+msgid "Add File(s)"
+msgstr "Adicionar Ficheiro(s)"
+
+msgid "All files are linked with this case."
+msgstr "Todos os ficheiros estão ligados a este caso."
+
+msgid "Add New File to Selected Case"
+msgstr "Adicionar novo ficheiro ao caso seleccionado"
+
+msgid "Case Memo"
+msgstr "Comentário de Caso"
+
+msgid "Case"
+msgstr "Caso"
+
+msgid "Show Cases with Memo Only"
+msgstr "Mostrar somente Casos com Comentário"
+
+msgid "Add/modify Attributes..."
+msgstr "Adicionar/modificar Atributos..."
+
+msgid "View Attributes"
+msgstr "Ver Atributos"
+
+msgid "Export Case Attributes"
+msgstr "Exportar Atributos do Caso"
+
+msgid "Sort All by Created Time"
+msgstr "Ordenar Tudo por tempo de criação"
+
+msgid "Web Search"
+msgstr "Pesquisar na Internet"
+
+msgid "Add To File Category ..."
+msgstr "Adicionar a Categoria de Ficheiro"
+
+msgid "Drop Selected File(s)"
+msgstr "Eliminar Ficheiro(s) Seleccionado(s)"
+
+msgid "Please select the Files you want to delete."
+msgstr "Por favor, seleccione os Ficheiros que deseja apagar."
+
+msgid "Delete %i file(s) from this category. Are you sure?"
+msgstr "Apagar %i ficheiros(s) desta categoria. Tem certeza?"
+
+msgid "Delete Selected File(s)"
+msgstr "Apagar Ficheiro(s) Seleccionado(s)"
+
+msgid "Edit Selected File"
+msgstr "Editar Ficheiro Seleccionado"
+
+msgid "File Memo"
+msgstr "Comentário de Ficheiro"
+
+msgid "File"
+msgstr "Ficheiro"
+
+msgid "Rename selected File"
+msgstr "Renomear Ficheiro Seleccionado"
+
+msgid "Select a file first."
+msgstr "Seleccione um ficheiro primeiro."
+
+msgid "Enter new file name."
+msgstr "Digite novo nome de ficheiro."
+
+msgid "Search Files within Seleted Case"
+msgstr "Pesquisar ficheiros no caso seleccionado"
+
+msgid "Please input a search pattern."
+msgstr "Por favor, entre um padrão de pesquisa."
+
+msgid "Error~~~."
+msgstr "Erro~~~."
+
+msgid "Show ..."
+msgstr "Mostrar ..."
+
+msgid "Show All by Sorted by Imported Time"
+msgstr "Mostrar todos ordenados por tempo de importação"
+
+msgid "Show Coded Files Only (sorted)"
+msgstr "Mostrar Somente Ficheiros Codificados (ordenados)"
+
+msgid "Show Uncoded Files Only (sorted)"
+msgstr "Mostrar Somente Ficheiros Não Codificados (ordenados)"
+
+msgid "Show Selected File Property"
+msgstr "Mostrar Propriedades do ficheiro seleccionado"
+
+msgid "Fail to write to database for case with id %i"
+msgstr "Falha ao escrever na base de dados para o caso com id %i"
+
+msgid "Enter new Code Category."
+msgstr "Digite um nova Categoria de Código."
+
+msgid "Really delete the Code Category?"
+msgstr "Realmente apagar Categoria de Código?"
+
+msgid "The Category Name is not unique."
+msgstr "O nome da Categoria não é único."
+
+msgid "Select a Code Category first."
+msgstr "Seleccione uma Categoria de código primeiro."
+
+msgid "Enter new Cateory name."
+msgstr "Digite um novo Nome de Categoria."
+
+msgid "Add To"
+msgstr "Adicionar a"
+
+msgid "No free codes yet."
+msgstr "Nenhum código livre ainda."
+
+msgid "Add code(s) to the selected code category."
+msgstr "Adicionar código(s) à categoria de código seleccionada."
+
+msgid "Drop From"
+msgstr "Remover de"
+
+msgid "Please select the Codes you want to delete."
+msgstr "Por favor, seleccione os Códigos que deseja apagar."
+
+msgid "Delete %i code(s) from this category. Are you sure?"
+msgstr "Apagar %i código(s) desta categoria. Tem certeza?"
+
+msgid "Drop selected code(s) from code category."
+msgstr "Remover código(s) seleccionados da categoria."
+
+msgid "Code Category"
+msgstr "Categoria de Código"
+
+msgid "Add New Code to Selected Category"
+msgstr "Adicionar um Novo Código à Categoria seleccionada"
+
+msgid "Enter new code."
+msgstr "Digite um novo código."
+
+msgid "Select a code category first."
+msgstr "Seleccionar uma categoria de código primeiro."
+
+msgid "Failed to assign code category"
+msgstr "Falha ao especificar categoria de código"
+
+msgid "Codings of selected category"
+msgstr "Codificações das categorias seleccionadas"
+
+msgid "Plot Selected Code Categories"
+msgstr "Plotar Categorias de Códigos seleccionadas"
+
+msgid "Plot Selected Code Categories with d3"
+msgstr "Plotar Categorias de Códigos seleccionadas com d3"
+
+msgid "Sort by created time"
+msgstr "Ordenar por tempo de criação"
+
+msgid "Rename Selected Code"
+msgstr "Renomear Código Seleccionado"
+
+msgid "Select a code first."
+msgstr "Seleccionar um código primeiro."
+
+msgid "Enter new code name."
+msgstr "Digite um novo código."
+
+msgid "Code Memo"
+msgstr "Comentário de Código"
+
+msgid "Code"
+msgstr "Código"
+
+msgid "Cannot update Code List in the Widget. Project is closed already."
+msgstr ""
+"Não é possível actualizar lista de códigos na Interface Gráfica. O projecto "
+"já está fechado."
+
+msgid "Save Coding Memo"
+msgstr "Guardar Comentário da Codificação"
+
+msgid "No Coding associated with the selected code."
+msgstr "Nenhuma codificação associada ao código seleccionado."
+
+msgid "cannot recode this text segment."
+msgstr "não é possível recodificar este segmento de texto."
+
+msgid "Selected code id is %s__%s codings"
+msgstr "ID do Código Seleccionado %s__%s codificações"
+
+msgid "Recode"
+msgstr "Recodificar"
+
+msgid "No Coding associated with the '%s'."
+msgstr "Nenhuma codificação associada com o '%s'."
+
+msgid "[Annotation]"
+msgstr "[Anotação]"
+
+msgid "Save Annotation"
+msgstr "Guardar anotação"
+
+msgid "Open a file first!"
+msgstr "Abra o ficheiro primeiro!"
+
+msgid "Add Code Categroy First."
+msgstr "Adicionar Categoria de Código primeiro."
+
+msgid "Fail to write to code category of %s"
+msgstr "Falha ao escrever na categoria de código de %s"
+
+msgid "Add"
+msgstr "Adicionar"
+
+msgid "Really delete the code?"
+msgstr "Realmente apagar o código?"
+
+msgid "No codings associated with this code."
+msgstr "Nenhuma codificação associada a este código."
+
+msgid "Retrieve codings of the selected code."
+msgstr "Obter codificações do códigos seleccionados."
+
+msgid "Open a file first."
+msgstr "Abrir um ficheiro primeiro."
+
+msgid "Fail to write to data base."
+msgstr "Falha ao escrever na base de dados."
+
+msgid "Select a code and one of its codings exactly first."
+msgstr "Seleccione um código e um de suas codificações primeiro."
+
+msgid "C-Memo"
+msgstr "Coment-C"
+
+msgid "code"
+msgstr "código"
+
+msgid "Memo for selected code."
+msgstr "Comentário para o código seleccionado."
+
+msgid "C2Memo"
+msgstr "Coment-C2"
+
+msgid "[Coding Memo]"
+msgstr "[Comentário de Codificação]"
+
+msgid "select a code first."
+msgstr "seleccione um código primeiro."
+
+msgid "Select the exact CODING AND the corresponding CODE first."
+msgstr "Seleccione a CODIFICAÇÃO exacta E o correspondente CÓDIGO primeiro."
+
+msgid "Memo for a Coding."
+msgstr "Comentário para uma Codificação."
+
+msgid "Add Anno"
+msgstr "Adicionar Anotação"
+
+msgid ""
+"Add new annotation to the open file\n"
+"at position of cursor."
+msgstr ""
+"Adicionar nova anotação ao ficheiro aberto\n"
+"na posição do cursor."
+
+msgid "Add To Code Category..."
+msgstr "Adicionar a Categoria de Código..."
+
+msgid "All Code Memos"
+msgstr "Todos os Comentários de Código"
+
+msgid "All Annotations"
+msgstr "Todas as Anotações"
+
+msgid "Codings of Multiple Codes"
+msgstr "Codificações de Múltiplos Códigos"
+
+msgid "Export Codings as HTML"
+msgstr "Exportar Codificações como HTML"
+
+msgid "Type a name for the exported codings and click OK."
+msgstr "Digite um nome para as codificações exportadas e clique OK."
+
+msgid "Highlight All Codings"
+msgstr "Realçar Todas as Codificações"
+
+msgid "Highlight Codings with Memo"
+msgstr "Realçar Codificações com Comentários"
+
+msgid "Merge Selected with..."
+msgstr "Juntar Seleccionado com..."
+
+msgid "Show Codes With Codings"
+msgstr "Mostrar Códigos com Codificações"
+
+msgid "Show Codes Without Codings"
+msgstr "Mostrar Códigos sem Codificações"
+
+msgid "Show Codes With Code Category"
+msgstr "Mostrar Códigos com Categoria de Código"
+
+msgid "All codes are assiged to code category."
+msgstr "Todos os códigos estão categorizados."
+
+msgid "Show Codes Without Code Category"
+msgstr "Mostrar Códigos sem Categoria de Código"
+
+msgid "Show Codes With Memo"
+msgstr "Mostrar Códigos com Comentário"
+
+msgid "No Code with memo."
+msgstr "Nenhum Código com Comentário."
+
+msgid "Show Codes Without Memo"
+msgstr "Mostrar Códigos sem Comentários"
+
+msgid "Show Codes With Selected File"
+msgstr "Mostrar Códigos com Ficheiro Seleccionado"
+
+msgid "Set Coding Mark Color"
+msgstr "Configurar Cor da Marca da Codificação"
+
+msgid "Sort: By Created Time"
+msgstr "Ordenar: Por Tempo de Criação"
+
+msgid "Sort: Most to Least Frequently Used"
+msgstr "Ordenar: Do Mais para o Menos frequentemente usado"
+
+msgid "Sort: Least to Most Frequently Used"
+msgstr "Ordenar: Do Menos para o Mais frequentemente usado"
+
+msgid "Import"
+msgstr "Importar"
+
+msgid "New"
+msgstr "Novo"
+
+msgid "Open"
+msgstr "Abrir"
+
+msgid "Save To Project"
+msgstr "Guardar no Projecto"
+
+msgid "Save and close"
+msgstr "Guardar e fechar"
+
+msgid "Add New File ..."
+msgstr "Adicionar Novo Ficheiro ..."
+
+msgid "Add To Case ..."
+msgstr "Adicionar ao Caso"
+
+msgid "Add/modify Attributes of The Open File..."
+msgstr "Adicionar/modificar Atributos do ficheiro aberto"
+
+msgid "Codings of selected file(s)"
+msgstr "Codificações do(s) ficheiro(s) seleccionado(s)"
+
+msgid "No coded file is selected."
+msgstr "Nenhum ficheiro codificado está seleccionado."
+
+msgid "Export File Attributes"
+msgstr "Exportar Atributos do Ficheiro"
+
+msgid "Edit Seleted File"
+msgstr "Editar Ficheiro Seleccionado"
+
+msgid "Export Coded file as HTML"
+msgstr "Exportar ficheiro codificado como HTML"
+
+msgid "File Annotations"
+msgstr "Anotações do Ficheiro"
+
+msgid "Import PDF Highligts via rjpod (selector)"
+msgstr "Importar realces de PDF via rjpod (selector)"
+
+msgid "Import PDF Highligts via rjpod (file path)"
+msgstr "Importar realces de PDF via rjpod (caminho de ficheiro)"
+
+msgid "Enter a pdf file path"
+msgstr "Digite um caminho para ficheiro pdf"
+
+msgid "Open Selected File"
+msgstr "Abrir o Ficheiro Seleccionado"
+
+msgid "Open Previous Coded File"
+msgstr "Abrir Ficheiro codificado anterior"
+
+msgid "Search for a Word"
+msgstr "Procurar uma palavra"
+
+msgid "Search all files ..."
+msgstr "Procurar em todos os ficheiros ..."
+
+msgid "Show All Sorted By Imported Time"
+msgstr "Mostrar todos ordenados por tempo de importação"
+
+msgid "Show Coded Files Sorted by Imported time"
+msgstr "Mostrar ficheiros codificados ordenados por tempo de importação"
+
+msgid "Show Uncoded Files Sorted by Imported time"
+msgstr "Mostrar ficheiros não codificados ordenados por tempo de importação"
+
+msgid "Show Files With Annotation"
+msgstr "Mostrar ficheiros com anotações"
+
+msgid "No file with memo."
+msgstr "Nenhum ficheiro com comentário."
+
+msgid "Show Files Without Annotation"
+msgstr "Mostrar ficheiros sem anotações"
+
+msgid "All files have annotation."
+msgstr "Todos os ficheiros têm anotações"
+
+msgid "Show Files With Memo"
+msgstr "Mostrar ficheiros com Comentário"
+
+msgid "Show Files Without Memo"
+msgstr "Mostrar ficheiros sem comentário"
+
+msgid "No file is found."
+msgstr "Nenhum ficheiro encontrado."
+
+msgid "Show Files Without File Category"
+msgstr "Mostrar Ficheiros sem Categoria de Ficheiro"
+
+msgid "All are linked with file category."
+msgstr "Todos estão ligados com a categoria de ficheiro."
+
+msgid "Show Files With No Case"
+msgstr "Mostrar ficheiro sem casos"
+
+msgid "All are linked with cases."
+msgstr "Todos estão ligados com casos."
+
+msgid "Enter new File Category."
+msgstr "Digite um nova Categoria de Ficheiro."
+
+msgid "Really delete the File Category?"
+msgstr "Realmente apagar Categoria de Ficheiro?"
+
+msgid "File Category"
+msgstr "Categoria de Ficheiro"
+
+msgid "Memo of file category."
+msgstr "Comentários de categoria de ficheiro."
+
+msgid "AddTo"
+msgstr "Adicionar A"
+
+msgid "No files Yet."
+msgstr "Nenhum ficheiro ainda."
+
+msgid "Add file(s) to the selected file category."
+msgstr "Adicionar ficheiro(s) à categoria de ficheiro seleccionada."
+
+msgid "DropFrom"
+msgstr "Remover De"
+
+msgid "Drop selected file(s) from file category."
+msgstr "Remover ficheiro(s) seleccionados da categoria."
+
+msgid "Delete all files of selected category"
+msgstr "Apagar todos os ficheiros da categoria seleccionada"
+
+msgid "Move To File Category ..."
+msgstr "Mover para Categoria de Ficheiro ..."
+
+msgid "Search Files Within Categroy"
+msgstr "Pesquisar Ficheiros na Categoria"
+
+msgid "Delete selected File(s)"
+msgstr "Apagar Ficheiro(s) Seleccionado(s)"
+
+msgid "Show All By Imported Time"
+msgstr "Mostrar Todos por Tempo de Importação"
+
+msgid "A file with the same name exists in the database!"
+msgstr "Um ficheiro com o mesmo nome existe na base de dados"
+
+msgid "Save File"
+msgstr "Guardar Ficheiro"
+
+msgid "Open a project first."
+msgstr "Abrir um projecto primeiro."
+
+msgid "Save memo"
+msgstr "Guardar comentário"
+
+msgid "select one file category only."
+msgstr "seleccione uma categoria de ficheiro somente."
+
+msgid "more than one file categories are selected"
+msgstr "mais de uma categoria de ficheiro está seleccionada"
+
+msgid "Add File Categroy first."
+msgstr "Adicionar Categoria de Ficheiro primeiro."
+
+msgid "Fail to write to file category of %s"
+msgstr "Falha ao escrever categoria de ficheiro de %s"
+
+msgid "Reach the end."
+msgstr "Fim alcançado."
+
+msgid "Search next"
+msgstr "Procurar próximo"
+
+msgid "Restart"
+msgstr "Reiniciar"
+
+msgid "Really delete the journal?"
+msgstr "Realmente apagar o item do diário?"
+
+msgid "Enter new journal name."
+msgstr "Digite novo nome de item do diário."
+
+msgid "Save Journal"
+msgstr "Guardar Diário"
+
+msgid "Select first."
+msgstr "Seleccione primeiro."
+
+msgid "The Journal has been changed. Close anyway?"
+msgstr "O item do Diário foi modificado. Fechar mesmo assim?"
+
+msgid "Profile Matrix - %s"
+msgstr "Matriz de perfis - %s"
+
+msgid "New Project"
+msgstr "Novo Projecto"
+
+msgid "Type a name for the new project and click OK."
+msgstr "Digite um nome para o projecto e clique OK."
+
+msgid "Open Project"
+msgstr "Abrir Projecto"
+
+msgid "Select a *.rqda file and click OK."
+msgstr "Seleccione um ficheiro *.rqda e clique OK."
+
+msgid "Opening ..."
+msgstr "Abrindo ..."
+
+msgid "Closing ..."
+msgstr "Fechando ..."
+
+msgid "No project is open."
+msgstr "Nenhum projecto está aberto."
+
+msgid "Files"
+msgstr "Ficheiros"
+
+msgid "Codes List"
+msgstr "Lista de Códigos"
+
+msgid "Codes of This Category"
+msgstr "Códigos desta Categoria"
+
+msgid "Cases"
+msgstr "Casos"
+
+msgid "Files of This Case"
+msgstr "Ficheiros deste Caso"
+
+msgid "Files of This Category"
+msgstr "Ficheiros desta Categoria"
+
+msgid "Close Project"
+msgstr "Fechar Projecto"
+
+msgid "Backup Project"
+msgstr "Cópia de Segurança do Projecto"
+
+msgid "Project Memo"
+msgstr "Comentário de Projecto"
+
+msgid "Clean Project"
+msgstr "Limpar Projecto"
+
+msgid "Close All Codings"
+msgstr "Fechar todas as Codificações"
+
+msgid "No write permission."
+msgstr "Sem permissão de escrita."
+
+msgid "Overwrite existing project?"
+msgstr "Sobrescrever o projecto existente?"
+
+msgid "You have no write permission to overwrite it."
+msgstr "Você não tem permissão de escrita para sobrescrevê-lo"
+
+msgid ""
+"You don't have write access to the *.rqda file. You can only read the "
+"project."
+msgstr ""
+"Você não tem permissão de escrita para o ficheiro *.rqda. Você pode somente "
+"ler o projecto"
+
+msgid "You don't have read access to the *.rqda file. Fail to open."
+msgstr ""
+"Você não tem permissão de leitura para o ficheiro *.rqda. Falha ao abrir."
+
+msgid "Closing project failed."
+msgstr "Falha ao fechar projecto."
+
+msgid "No Project is Open."
+msgstr "Nenhum Projecto está Aberto."
+
+msgid "Succeeded!"
+msgstr "Sucesso!"
+
+msgid "Fail to back up the project."
+msgstr "Falha ao fazer cópia de segurança do projecto."
+
+msgid "The memo has bee change. Close anyway?"
+msgstr "O comentário foi modificado. Fechar mesmo assim?"
+
+msgid "Settings"
+msgstr "Configurações"
+
+msgid "Name of Coder"
+msgstr "Nome do Codificador"
+
+msgid "File Encoding"
+msgstr "Codificação do Ficheiro"
+
+msgid "Color for Coding"
+msgstr "Cor para Codificação"
+
+msgid "Color for Case"
+msgstr "Cor para Caso"
+
+msgid "Current coding table"
+msgstr "Tabela de codificação actual"
+
+msgid "Byte Order Mark"
+msgstr "Marca de Ordem de Byte"
+
+msgid "Show File Property"
+msgstr "Mostrar Propriedades do Ficheiro"
+
+msgid "Type of Retrieval"
+msgstr "Tipo de Recuperação"
+
+msgid "unconditional"
+msgstr "incondicional"
+
+msgid "case"
+msgstr "caso"
+
+msgid "filecategory"
+msgstr "categoria de ficheiro"
+
+msgid "both"
+msgstr "ambos"
+
+msgid "Click to set font"
+msgstr "Clique para configurar a fonte"
+
+msgid "Set fonts for memo widgets."
+msgstr "Configure fonte para janela de comentário."
+
+msgid "Default"
+msgstr "Padrão"
+
+msgid "OK"
+msgstr "OK"
+
+msgid "Change color."
+msgstr "Mudar cor."
+
+msgid "Select Color"
+msgstr "Seleccionar Cor"
+
+msgid "Changing color"
+msgstr "Mudança de cor"
+
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgid "Are you sure to clean the coding table?"
+msgstr "Tem certeza de limpar a tabela de codificação?"
+
+msgid "One code has empty coding."
+msgstr "Um código tem codificação vazia."
+
+msgid "Each line represents one relation only"
+msgstr "Cada linha representa apenas uma relação"
+
+msgid "index1 and index2 must be vector."
+msgstr "index1 e index2 devem ser vectores."
+
+msgid "index1 or index2 should not have any NA."
+msgstr "index1 ou index2 não devem ter nenhum NA."
+
+msgid "No coding in this project."
+msgstr "Nenhuma codificação neste projecto."
+
+msgid "Codes without codings dropped."
+msgstr "Códigos não usados serão eliminados."
+
+msgid "The codeList should be a vector of length 2 or greater"
+msgstr "A lista de códigos deve ser um vector de tamanho 2 ou maior."
+
+msgid "RQDA has been launched."
+msgstr "RQDA foi iniciado."
+
+msgid "RQDA: Qualitative Data Analysis"
+msgstr "RQDA: Análise de Dados Qualitativos"
+
+msgid "Project"
+msgstr "Projecto"
+
+msgid "Save Project As"
+msgstr "Guardar Projecto como"
+
+msgid "Path of current project:"
+msgstr "Caminho para o projecto actual:"
+
+msgid "Author: <ronggui.huang@gmail.com>"
+msgstr "Autor: <ronggui.huang@gmail.com>"
+
+msgid "Help: click to join rqda-help mailing list"
+msgstr "Ajuda: clique para juntar-se à mailing list rqda-help"
+
+msgid "License: BSD"
+msgstr "Licença: BSD"
+
+msgid "Version:"
+msgstr "Versão:"
+
+msgid "Year:"
+msgstr "Ano:"
+
+msgid "Please cite this package."
+msgstr "Por favor, cite este pacote."
+
+msgid "About"
+msgstr "Sobre"
+
+msgid "Codes"
+msgstr "Códigos"
+
+msgid "Anno"
+msgstr "Anotação"
+
+msgid "Coding"
+msgstr "Codificação"
+
+msgid ""
+"Code\n"
+"Categories"
+msgstr ""
+"Categorias\n"
+"de Códigos"
+
+msgid "Please click Update"
+msgstr "Por favor, clique Actualizar"
+
+msgid "UnMark"
+msgstr "Desmarcar"
+
+msgid "Unlink"
+msgstr "Desligar"
+
+msgid "Link"
+msgstr "Ligar"
+
+msgid "Profile"
+msgstr "Perfil"
+
+msgid ""
+"File\n"
+"Categories"
+msgstr ""
+"Categorias\n"
+"de Ficheiros"
+
+msgid "Journals"
+msgstr "Diário"
+
+msgid ""
+"Really EXIT?\n"
+"\n"
+"You can use RQDA() to start this program again."
+msgstr ""
+"Realmente SAIR?\n"
+"\n"
+"Você pode usar 'RQDA()' para iniciar o programa novamente."
+
+msgid "Selected File id is %s"
+msgstr "ID do Ficheiro Seleccionado %s"
+
+msgid "No coding associated with this code."
+msgstr "Nenhuma codificação associada a este projecto."
+
+msgid "Selected case id is %i__%i files"
+msgstr "ID do caso seleccionado %i__%i ficheiros"
+
+msgid "Selected category id is %s"
+msgstr "O id do Categoria seleccionada é %s"
+
+msgid "Selected file id is %s"
+msgstr "ID do ficheiro seleccionado %s"
+
+msgid "Save Project As ..."
+msgstr "Guardar Projecto como ..."
+
+msgid "Type a new file name and click OK."
+msgstr "Digite um nome para o ficheiro e clique OK."
+
+msgid "Failed to save the project to the new location."
+msgstr "Falha ao guardar o projecto no novo local."
+
+msgid "The new name is duplicated. Please use another new name."
+msgstr "O novo nome é duplicado. Por favor, escolha outro."
+
+msgid "The memo has been changed. Close anyway?"
+msgstr "O comentário foi modificado. Fechar mesmo assim?"
+
+msgid "%s Memo:%s"
+msgstr "Comentário de %s: %s"
+
+msgid "Save Memo"
+msgstr "Guardar Comentário"
+
+msgid "No Information is collected."
+msgstr "Nenhuma Informação colectada."
+
+msgid "%i retrieved file(s)."
+msgstr "%i retrieved file(s)."
+
+msgid "Select before Click OK."
+msgstr "Seleccione antes de clicar OK."
+
+msgid "File Category is %s"
+msgstr "A Categoria do Ficheiro é %s"
+
+msgid ""
+"File ID is %i \n"
+" %s \n"
+"Case is %s"
+msgstr ""
+"O ID do ficheiro é %i \n"
+" %s \n"
+"Caso é %s"
+
+msgid "Please select one file only."
+msgstr "Por favor, seleccione um somente ficheiro."
+
+msgid "File Property"
+msgstr "Propriedades do Ficheiro"
+
+msgid "No project is opened."
+msgstr "Nenhum projecto está aberto."
+
+msgid "The codeList should be a vector of length 2 or greater."
+msgstr "A lista de códigos deve ser um vector de tamanho 2 ou maior."
+
+msgid "Use 'RQDA()' to start the programme."
+msgstr "Use 'RQDA()' para iniciar o programa."
+
+msgid "1 coding from %i file"
+msgid_plural "1 coding from %i files"
+msgstr[0] "1 codificação de %i ficheiro"
+msgstr[1] "1 codificação de %i ficheiros"
+
+msgid "%i codings from %i file"
+msgid_plural "%i codings from %i files"
+msgstr[0] "%i codificações de %i ficheiro"
+msgstr[1] "%i codificações de %i ficheiros"
+
+msgid "1 retrieved coding: \"%s\" from %i file"
+msgid_plural "1 retrieved coding: \"%s\" from %i files"
+msgstr[0] "1 codificação recuperada: \"%s\" de %i ficheiro"
+msgstr[1] "1 codificação recuperada: \"%s\" de %i ficheiros"
+
+msgid "%i retrieved codings: \"%s\" from %i file"
+msgid_plural "%i retrieved codings: \"%s\" from %i files"
+msgstr[0] "%i codificações recuperadas: \"%s\" de %i ficheiro"
+msgstr[1] "%i codificações recuperadas: \"%s\" de %i ficheiros"
+
+msgid "%i Coding of <a id='%s'>\"%s\"</a> from %s file."
+msgid_plural "%i Coding of <a id='%s'>\"%s\"</a> from %s files."
+msgstr[0] "%i Codificação de <a id='%s'>\"%s\"</a> em %s ficheiro."
+msgstr[1] "%i Codificação de <a id='%s'>\"%s\"</a> em %s ficheiros."
+
+msgid "%i Codings of <a id='%s'>\"%s\"</a> from %s file."
+msgid_plural "%i Codings of <a id='%s'>\"%s\"</a> from %s files."
+msgstr[0] "%i Codificações de <a id='%s'>\"%s\"</a> em %s ficheiro."
+msgstr[1] "%i Codificações de <a id='%s'>\"%s\"</a> em %s ficheiros."
+
+msgid "Annotation"
+msgid_plural "Annotations"
+msgstr[0] "Anotação"
+msgstr[1] "Anotações"
+
+msgid "Really delete the file?"
+msgid_plural "Really delete the files?"
+msgstr[0] "Realmente apagar o ficheiro?"
+msgstr[1] "Realmente apagar os ficheiros?"
+
+msgid "1 retrieved coding from %i file"
+msgid_plural "1 retrieved coding from %i files"
+msgstr[0] "1 codificação recuperada de %i ficheiro"
+msgstr[1] "1 codificação recuperada de %i ficheiros"
+
+msgid "%i retrieved codings from %i file"
+msgid_plural "%i retrieved codings from %i files"
+msgstr[0] "%i codificações recuperadas de %i ficheiro"
+msgstr[1] "%i codificações recuperadas de %i ficheiros"
+
+msgid "annotation"
+msgid_plural "annotations"
+msgstr[0] "anotação"
+msgstr[1] "anotações"
+
+msgid "memo"
+msgid_plural "memos"
+msgstr[0] "comentário"
+msgstr[1] "comentários"


### PR DESCRIPTION
- Add a po directory, including a Makefile and Portuguese translations.
- Wrap RQDA messages with gettext(). The argument domain="R-RQDA" is
  necessary because the domain does not get defined when RQDA() is
  called from .onAttach() function, and also because some strings do
  get translated even if RQDA() is called manually (it seems that they
  get RGtk2 domain).
- Put the creation of pop up menus into functions because if the pop
  up menus are created while the package is being loaded, the messages
  do not get translated.
- "Untranslate" the Type Of Retrieve before using it from the Settings
  widget.
