### PR TITLE
fixed codingBySearch

### DIFF
--- a/R/autoCoding.R
+++ b/R/autoCoding.R
@@ -62,16 +62,16 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
     Encoding(txt) <- "UTF-8"
 
     ## find all pattern matches
-    patternmatches <- gregexpr(pattern,txt, ...)[[1]]
-    if (length(patternmatches) > 1 || (patternmatches != -1)) {
+    pattern_matches <- gregexpr(pattern,txt, ...)[[1]]
+    if (length(pattern_matches) > 1 || (pattern_matches != -1)) {
       
         ## get all separator matches and calculate start and end of each analysis unit
-        pidx <- gregexpr(sprintf("(%s){1,}", seperator),txt)
-        idx1 <- c(0,pidx[[1]]+attr(pidx[[1]],"match.length")-1)
-        idx2 <- c(pidx[[1]]-1,nchar(txt))
+        separator_matches <- gregexpr(sprintf("(%s){1,}", seperator),txt)[[1]]
+        idx1 <- c(0,separator_matches+attr(separator_matches,"match.length")-1)
+        idx2 <- c(separator_matches-1,nchar(txt))
     
         ## get the matching analysis units
-        residx <- unique(findInterval(patternmatches,sort(c(idx1,idx2))))
+        residx <- unique(findInterval(pattern_matches,sort(c(idx1,idx2))))
         idx <- (residx + 1)/2
         
         if (concatenate)

--- a/R/autoCoding.R
+++ b/R/autoCoding.R
@@ -60,18 +60,28 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
   ## by providing approperiate seperator, it allows flexible control on the unit of autocoding
     txt <- RQDAQuery(sprintf("select file from source where status=1 and id=%s",fid))$file
     Encoding(txt) <- "UTF-8"
+    
+    ## get all separator matches and calculate start and end of each analysis unit
     pidx <- gregexpr(sprintf("(%s){1,}", seperator),txt)
     idx1 <- c(0,pidx[[1]]+attr(pidx[[1]],"match.length")-1)
     idx2 <- c(pidx[[1]]-1,nchar(txt))
+    
+    ## find all pattern matches
     sidx <- gregexpr(pattern,txt, ...)[[1]]
+    
     if (length(sidx) > 1 || (sidx != -1)) {
+      
+        ## get the matching analysis units
         residx <- unique(findInterval(sidx,sort(c(idx1,idx2))))
         idx <- (residx + 1)/2
+        
         if (concatenate)
+            ## mark bordering matching analysis units
             removeidx <- which(diff(idx)==1)
         else
             removeidx <- NULL
         
+        ## receive start and end indexes of the matching analysis units
         if (length(removeidx) > 0) {
           selfirst = idx1[idx[-(removeidx+1)]]
           elend   = idx2[idx[-removeidx]]
@@ -80,6 +90,7 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
           selend   = idx2[idx]
         }
         
+        ## add the codings
         for (c in cid)
           for (i in (1:length(selfirst)))
             insertCoding (fid=fid, cid=c, start=selfirst[i], end=selend[i], txt)

--- a/R/autoCoding.R
+++ b/R/autoCoding.R
@@ -84,7 +84,7 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
         ## receive start and end indexes of the matching analysis units
         if (length(removeidx) > 0) {
           selfirst = idx1[idx[-(removeidx+1)]]
-          elend   = idx2[idx[-removeidx]]
+          selend   = idx2[idx[-removeidx]]
         } else {
           selfirst = idx1[idx]
           selend   = idx2[idx]

--- a/R/autoCoding.R
+++ b/R/autoCoding.R
@@ -67,11 +67,11 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
       
         ## get all separator matches and calculate start and end of each analysis unit
         separator_matches <- gregexpr(sprintf("(%s){1,}", seperator),txt)[[1]]
-        idx1 <- c(0,separator_matches+attr(separator_matches,"match.length")-1)
-        idx2 <- c(separator_matches-1,nchar(txt))
+        unit_start_indexes <- c(0,separator_matches+attr(separator_matches,"match.length")-1)
+        unit_end_indexes <- c(separator_matches-1,nchar(txt))
     
         ## get the matching analysis units
-        residx <- unique(findInterval(pattern_matches,sort(c(idx1,idx2))))
+        residx <- unique(findInterval(pattern_matches,sort(c(unit_start_indexes,unit_end_indexes))))
         idx <- (residx + 1)/2
         
         if (concatenate)
@@ -82,11 +82,11 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
         
         ## receive start and end indexes of the matching analysis units
         if (length(removeidx) > 0) {
-          selfirst = idx1[idx[-(removeidx+1)]]
-          selend   = idx2[idx[-removeidx]]
+          selfirst = unit_start_indexes[idx[-(removeidx+1)]]
+          selend   = unit_end_indexes[idx[-removeidx]]
         } else {
-          selfirst = idx1[idx]
-          selend   = idx2[idx]
+          selfirst = unit_start_indexes[idx]
+          selend   = unit_end_indexes[idx]
         }
         
         ## add the codings

--- a/R/autoCoding.R
+++ b/R/autoCoding.R
@@ -62,8 +62,8 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
     Encoding(txt) <- "UTF-8"
 
     ## find all pattern matches
-    sidx <- gregexpr(pattern,txt, ...)[[1]]
-    if (length(sidx) > 1 || (sidx != -1)) {    
+    patternmatches <- gregexpr(pattern,txt, ...)[[1]]
+    if (length(patternmatches) > 1 || (patternmatches != -1)) {
       
         ## get all separator matches and calculate start and end of each analysis unit
         pidx <- gregexpr(sprintf("(%s){1,}", seperator),txt)
@@ -71,7 +71,7 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
         idx2 <- c(pidx[[1]]-1,nchar(txt))
     
         ## get the matching analysis units
-        residx <- unique(findInterval(sidx,sort(c(idx1,idx2))))
+        residx <- unique(findInterval(patternmatches,sort(c(idx1,idx2))))
         idx <- (residx + 1)/2
         
         if (concatenate)

--- a/R/autoCoding.R
+++ b/R/autoCoding.R
@@ -60,17 +60,16 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
   ## by providing approperiate seperator, it allows flexible control on the unit of autocoding
     txt <- RQDAQuery(sprintf("select file from source where status=1 and id=%s",fid))$file
     Encoding(txt) <- "UTF-8"
-    
-    ## get all separator matches and calculate start and end of each analysis unit
-    pidx <- gregexpr(sprintf("(%s){1,}", seperator),txt)
-    idx1 <- c(0,pidx[[1]]+attr(pidx[[1]],"match.length")-1)
-    idx2 <- c(pidx[[1]]-1,nchar(txt))
-    
+
     ## find all pattern matches
     sidx <- gregexpr(pattern,txt, ...)[[1]]
-    
-    if (length(sidx) > 1 || (sidx != -1)) {
+    if (length(sidx) > 1 || (sidx != -1)) {    
       
+        ## get all separator matches and calculate start and end of each analysis unit
+        pidx <- gregexpr(sprintf("(%s){1,}", seperator),txt)
+        idx1 <- c(0,pidx[[1]]+attr(pidx[[1]],"match.length")-1)
+        idx2 <- c(pidx[[1]]-1,nchar(txt))
+    
         ## get the matching analysis units
         residx <- unique(findInterval(sidx,sort(c(idx1,idx2))))
         idx <- (residx + 1)/2

--- a/R/autoCoding.R
+++ b/R/autoCoding.R
@@ -58,32 +58,32 @@ insertCoding <- function(fid, cid, start, end, fulltext) {
 codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...) {
   ## auto coding: when seperator is \n, each paragraph is a analysis unit
   ## by providing approperiate seperator, it allows flexible control on the unit of autocoding
-    txt <- RQDAQuery(sprintf("select file from source where status=1 and id=%s",fid))$file
+    txt <- RQDAQuery(sprintf("select file from source where status=1 and id=%s", fid))$file
     Encoding(txt) <- "UTF-8"
 
     ## find all pattern matches
-    pattern_matches <- gregexpr(pattern,txt, ...)[[1]]
+    pattern_matches <- gregexpr(pattern, txt, ...)[[1]]
     if (length(pattern_matches) > 1 || (pattern_matches != -1)) {
       
         ## get all separator matches and calculate start and end of each analysis unit
-        separator_matches <- gregexpr(sprintf("(%s){1,}", seperator),txt)[[1]]
-        unit_start_indexes <- c(0,separator_matches+attr(separator_matches,"match.length")-1)
-        unit_end_indexes <- c(separator_matches-1,nchar(txt))
+        separator_matches <- gregexpr(sprintf("(%s){1,}", seperator), txt)[[1]]
+        unit_start_indexes <- c(0, separator_matches + attr(separator_matches, "match.length") - 1)
+        unit_end_indexes <- c(separator_matches - 1, nchar(txt))
     
         ## get the matching analysis units
-        residx <- unique(findInterval(pattern_matches,sort(c(unit_start_indexes,unit_end_indexes))))
-        idx <- (residx + 1)/2
+        residx <- unique(findInterval(pattern_matches, sort(c(unit_start_indexes, unit_end_indexes))))
+        idx <- (residx + 1) / 2
         
         if (concatenate)
             ## mark bordering matching analysis units
-            removeidx <- which(diff(idx)==1)
+            removeidx <- which(diff(idx) == 1)
         else
             removeidx <- NULL
         
         ## receive start and end indexes of the matching analysis units
         if (length(removeidx) > 0) {
-          selfirst = unit_start_indexes[idx[-(removeidx+1)]]
-          selend   = unit_end_indexes[idx[-removeidx]]
+          selfirst = unit_start_indexes[idx[ - (removeidx + 1)]]
+          selend   = unit_end_indexes[idx[ - removeidx]]
         } else {
           selfirst = unit_start_indexes[idx]
           selend   = unit_end_indexes[idx]
@@ -91,7 +91,7 @@ codingBySearchOneFile <- function(pattern, fid, cid, seperator, concatenate, ...
         
         ## add the codings
         for (c in cid)
-          for (i in (1:length(selfirst)))
+          for (i in (1 : length(selfirst)))
             insertCoding (fid=fid, cid=c, start=selfirst[i], end=selend[i], txt)
     }
 }


### PR DESCRIPTION
Dear Ronggui,

I tried myself on fixing and enhancing the codingBySearch function:
* fixed a bug with a misspelled variable name that broke concatenation functionality: https://github.com/Ronggui/RQDA/commit/2e1b9becf698f64199914173bc9272d8f9ede992
* added comments and renamed local variable names for better maintainability.
* improved functionality to allow more fine grained search and code functionality: https://github.com/Ronggui/RQDA/commit/0166f7220299174b25c7067097dcf518bfcf714f

I was especially interested in fixing cases, where the coding search `pattern` spanned across multiple analysis units (e.g. multi word patterns combined with a space separator). I took special care on the concatenate functionality to keep compatibility.

I tested with the following examples:

#### multi word
"The Semantic Web shares many goals with Decision Support Systems DSS, e.g., being able to precisely interpret information, in order to deliver relevant, reliable and accurate information to a user when and where it is needed."
```
codingBySearch("Decision Support System", fid=getFileIds(), cid=1, seperator="[ .,;-]")
```
#### concatenation
"Large amounts of Linked Data Linked Data geo-spatial information have been made available with the growth of the Web of Data."
```
codingBySearch("Linked Data", fid=getFileIds(), cid=1, seperator="[ .,;-]", concatenate=TRUE)
```

#### concatenation 2
"The Subject-Predicate-Object triple annotation system is now well adopted in the research community, however, it does not always speak to end-users."
```
codingBySearch("Subject|Predicate|Object", fid=getFileIds(), cid=1, seperator="[ .,;-]", concatenate=TRUE)
```